### PR TITLE
Fix package definition and clean up SwiftUI data handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,7 @@
 // swift-tools-version:5.5
 import PackageDescription
 
-let packge = Package(
+let package = Package(
     name: "FamilyApp",
     platforms: [
         .macOS(.v11)

--- a/Sources/FamilyApp/Data/DataStore.swift
+++ b/Sources/FamilyApp/Data/DataStore.swift
@@ -1,5 +1,21 @@
 import Foundation
+#if canImport(Combine)
+import Combine
+#elseif canImport(SwiftUI)
 import SwiftUI
+#else
+/// Minimal stand-ins so the package can be built on platforms without Combine/SwiftUI (e.g. Linux).
+public protocol ObservableObject: AnyObject {}
+
+@propertyWrapper
+public struct Published<Value> {
+    public var wrappedValue: Value
+    public init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+    }
+    public var projectedValue: Published<Value> { self }
+}
+#endif
 
 /// A persistent data store that holds family members, tasks, and events.
 ///

--- a/Sources/FamilyApp/Views/AddTaskView.swift
+++ b/Sources/FamilyApp/Views/AddTaskView.swift
@@ -24,15 +24,17 @@ struct AddTaskView: View {
                     }
                 }
                 Section(header: Text("Assign To")) {
-                    Picker("Family Member", selection: Binding(
-                        get: { assignedMemberID ?? dataStore.members.first?.id },
-                        set: { assignedMemberID = $0 }
-                    )) {
-                        ForEach(dataStore.members, id: \ .id) { member in
-                            Text(member.name).tag(member.id as UUID?)
+                    if dataStore.members.isEmpty {
+                        Text("Add a family member to assign this task.")
+                            .foregroundColor(.secondary)
+                    } else {
+                        Picker("Family Member", selection: $assignedMemberID) {
+                            ForEach(dataStore.members) { member in
+                                Text(member.name).tag(member.id as UUID?)
+                            }
                         }
+                        .pickerStyle(PopUpButtonPickerStyle())
                     }
-                    .pickerStyle(PopUpButtonPickerStyle())
                 }
             }
             .navigationTitle("New Task")
@@ -45,6 +47,10 @@ struct AddTaskView: View {
                         .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
+            .onAppear(perform: updateDefaultAssignedMember)
+            .onChange(of: dataStore.members.count) { _ in
+                updateDefaultAssignedMember()
+            }
         }
     }
 
@@ -52,6 +58,7 @@ struct AddTaskView: View {
     private func addTask() {
         let trimmedTitle = title.trimmingCharacters(in: .whitespaces)
         guard !trimmedTitle.isEmpty else { return }
+        updateDefaultAssignedMember()
         let task = Task(
             id: UUID(),
             title: trimmedTitle,
@@ -61,5 +68,20 @@ struct AddTaskView: View {
         )
         dataStore.addTask(task)
         isPresented = false
+    }
+
+    /// Ensures there is always a valid member selected when the list is non-empty.
+    private func updateDefaultAssignedMember() {
+        guard !dataStore.members.isEmpty else {
+            assignedMemberID = nil
+            return
+        }
+
+        if let currentID = assignedMemberID,
+           dataStore.members.contains(where: { $0.id == currentID }) {
+            return
+        }
+
+        assignedMemberID = dataStore.members.first?.id
     }
 }

--- a/Sources/FamilyApp/Views/EventsView.swift
+++ b/Sources/FamilyApp/Views/EventsView.swift
@@ -40,11 +40,13 @@ struct EventsView: View {
         }
     }
 
-    /// A date formatter for displaying event dates.
-    private var dateFormatter: DateFormatter {
+    /// A shared date formatter for displaying event dates.
+    private static let eventDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter
-    }
+    }()
+
+    private var dateFormatter: DateFormatter { Self.eventDateFormatter }
 }

--- a/Sources/FamilyApp/Views/MembersView.swift
+++ b/Sources/FamilyApp/Views/MembersView.swift
@@ -40,10 +40,12 @@ struct MembersView: View {
         }
     }
 
-    /// A date formatter used for displaying birthdays in a friendly way.
-    private var dateFormatter: DateFormatter {
+    /// A shared date formatter used for displaying birthdays in a friendly way.
+    private static let birthdayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         return formatter
-    }
+    }()
+
+    private var dateFormatter: DateFormatter { Self.birthdayFormatter }
 }

--- a/Sources/FamilyApp/Views/TasksView.swift
+++ b/Sources/FamilyApp/Views/TasksView.swift
@@ -48,11 +48,13 @@ struct TasksView: View {
         }
     }
 
-    /// A date formatter for displaying due dates.
-    private var dateFormatter: DateFormatter {
+    /// A shared date formatter for displaying due dates.
+    private static let dueDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return formatter
-    }
+    }()
+
+    private var dateFormatter: DateFormatter { Self.dueDateFormatter }
 }


### PR DESCRIPTION
## Summary
- correct the package manifest typo so SwiftPM recognizes the executable target
- make the data store import Combine when available and fall back to lightweight stubs for Linux builds
- repair the task assignment picker and share cached date formatters across SwiftUI lists to avoid redundant work

## Testing
- `swift build` *(fails: SwiftUI framework is unavailable in the Linux container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1186760d4832bb315df11ded3f40b