### PR TITLE
Initialize Hive before opening boxes

### DIFF
--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
 import 'models/chat.dart';
@@ -15,6 +16,7 @@ import 'screens/members_screen.dart';
 /// as needed.
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
   final chatProvider = ChatProvider();
   await chatProvider.init();
   runApp(MyApp(chatProvider: chatProvider));


### PR DESCRIPTION
## Summary
- import `hive_flutter` in the app entrypoint and initialize Hive before opening boxes so Hive-backed providers can start correctly

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d134990664832bbda495fa97eed647