### PR TITLE
Fix Flutter task model mismatches and clean analyzer errors

### DIFF
--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
-import 'models/chat.dart';
 import 'providers/family_data.dart';
 import 'providers/chat_provider.dart';
 import 'providers/friends_data.dart';

--- a/FamilyAppFlutter/lib/screens/add_task_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_task_screen.dart
@@ -22,7 +22,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
     final task = Task(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       title: title,
-      status: TaskStatus.pending,
+      status: TaskStatus.todo,
       points: 0,
     );
     Provider.of<FamilyData>(context, listen: false).addTask(task);

--- a/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
+++ b/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
@@ -74,15 +74,16 @@ class _AiSuggestionsScreenState extends State<AiSuggestionsScreen> {
         _error = 'Ошибка генерации: $e';
       });
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 
   String _fmtDate(DateTime dt) {
-    final two = (int n) => n.toString().padLeft(2, '0');
+    String two(int n) => n.toString().padLeft(2, '0');
     return '${two(dt.day)}.${two(dt.month)}.${dt.year} ${two(dt.hour)}:${two(dt.minute)}';
   }
 
@@ -141,8 +142,8 @@ class _AiSuggestionsScreenState extends State<AiSuggestionsScreen> {
                   width: double.infinity,
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Colors.red.withOpacity(0.08),
-                    border: Border.all(color: Colors.red.withOpacity(0.3)),
+                    color: Colors.red.withValues(alpha: 0.08),
+                    border: Border.all(color: Colors.red.withValues(alpha: 0.3)),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -172,11 +173,11 @@ class _AiSuggestionsScreenState extends State<AiSuggestionsScreen> {
                               color: Theme.of(context)
                                   .colorScheme
                                   .surface
-                                  .withOpacity(0.6),
+                                  .withValues(alpha: 0.6),
                               border: Border.all(
                                 color: Theme.of(context)
                                     .dividerColor
-                                    .withOpacity(0.3),
+                                    .withValues(alpha: 0.3),
                               ),
                               borderRadius: BorderRadius.circular(10),
                             ),

--- a/FamilyAppFlutter/lib/screens/calendar_screen.dart
+++ b/FamilyAppFlutter/lib/screens/calendar_screen.dart
@@ -27,8 +27,8 @@ class CalendarScreen extends StatelessWidget {
             ));
             children.addAll(data.events.map((Event e) {
               return ListTile(
-                title: Text(e.title ?? ''),
-                subtitle: Text(e.startDateTime?.toString() ?? ''),
+                title: Text(e.title),
+                subtitle: Text(e.startDateTime.toString()),
               );
             }));
           }
@@ -42,7 +42,7 @@ class CalendarScreen extends StatelessWidget {
             ));
             children.addAll(data.tasks.map((Task t) {
               return ListTile(
-                title: Text(t.title ?? ''),
+                title: Text(t.title),
                 subtitle: Text(t.dueDate?.toString() ?? ''),
               );
             }));

--- a/FamilyAppFlutter/lib/screens/events_screen.dart
+++ b/FamilyAppFlutter/lib/screens/events_screen.dart
@@ -17,7 +17,7 @@ class EventsScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('Events')),
       body: Consumer<FamilyData>(
         builder: (context, data, _) {
-          final events = data.events;
+          final List<Event> events = data.events;
           if (events.isEmpty) {
             return const Center(child: Text('No events added yet.'));
           }
@@ -27,8 +27,8 @@ class EventsScreen extends StatelessWidget {
               final event = events[index];
               return ListTile(
                 leading: const Icon(Icons.event),
-                title: Text(event.title ?? ''),
-                subtitle: Text(event.startDateTime?.toString() ?? ''),
+                title: Text(event.title),
+                subtitle: Text(event.startDateTime.toString()),
               );
             },
           );

--- a/FamilyAppFlutter/lib/screens/members_screen.dart
+++ b/FamilyAppFlutter/lib/screens/members_screen.dart
@@ -15,7 +15,7 @@ class MembersScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<FamilyData>(
       builder: (context, data, _) {
-        final members = data.members;
+        final List<FamilyMember> members = data.members;
         return Scaffold(
           appBar: AppBar(title: const Text('Members')),
           body: members.isEmpty

--- a/FamilyAppFlutter/lib/screens/schedule_screen.dart
+++ b/FamilyAppFlutter/lib/screens/schedule_screen.dart
@@ -24,8 +24,8 @@ class ScheduleScreen extends StatelessWidget {
               final ScheduleItem item = data.items[index];
               return ListTile(
                 leading: const Icon(Icons.calendar_today),
-                title: Text(item.title ?? ''),
-                subtitle: Text(item.dateTime?.toString() ?? ''),
+                title: Text(item.title),
+                subtitle: Text(item.dateTime.toString()),
               );
             },
           );

--- a/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
+++ b/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
@@ -22,10 +22,15 @@ class ScoreboardScreen extends StatelessWidget {
         builder: (context, data, _) {
           // Create a copy to sort without mutating the original list.
           final List<FamilyMember> members = List<FamilyMember>.from(data.members);
+          final Map<String, int> pointsByMember = {
+            for (final member in members)
+              member.id: _calculatePointsForMember(member, data.tasks),
+          };
+
           // Sort by points descending, then by name ascending.
           members.sort((a, b) {
-            final int pointsA = _calculatePointsForMember(a, data.tasks);
-            final int pointsB = _calculatePointsForMember(b, data.tasks);
+            final int pointsA = pointsByMember[a.id] ?? 0;
+            final int pointsB = pointsByMember[b.id] ?? 0;
             if (pointsA == pointsB) {
               return (a.name ?? '').compareTo(b.name ?? '');
             }
@@ -35,13 +40,14 @@ class ScoreboardScreen extends StatelessWidget {
             itemCount: members.length,
             itemBuilder: (context, index) {
               final member = members[index];
-              final int points = _calculatePointsForMember(member, data.tasks);
+              final int points = pointsByMember[member.id] ?? 0;
               return ListTile(
                 leading: CircleAvatar(
-                  backgroundColor: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                  backgroundColor:
+                      Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
                   child: Text('${index + 1}'),
                 ),
-                title: Text(member.name ?? ''),
+                title: Text(member.name?.isNotEmpty == true ? member.name! : 'Unnamed'),
                 subtitle: Text(member.relationship ?? ''),
                 trailing: Text(
                   '$points pts',
@@ -60,7 +66,7 @@ class ScoreboardScreen extends StatelessWidget {
   int _calculatePointsForMember(FamilyMember member, List<Task> tasks) {
     var total = 0;
     for (final task in tasks) {
-      if (task.assignedMemberId == member.id && task.status == TaskStatus.completed) {
+      if (task.assigneeId == member.id && task.status == TaskStatus.done) {
         total += task.points ?? 0;
       }
     }

--- a/FamilyAppFlutter/lib/screens/tasks_screen.dart
+++ b/FamilyAppFlutter/lib/screens/tasks_screen.dart
@@ -26,8 +26,8 @@ class TasksScreen extends StatelessWidget {
               final Task task = tasks[index];
               return ListTile(
                 leading: const Icon(Icons.check_box_outline_blank),
-                title: Text(task.title ?? ''),
-                subtitle: Text(task.status?.toString().split('.').last ?? ''),
+                title: Text(task.title),
+                subtitle: Text(task.status.name),
               );
             },
           );

--- a/FamilyAppFlutter/lib/services/firestore_service.dart
+++ b/FamilyAppFlutter/lib/services/firestore_service.dart
@@ -47,8 +47,9 @@ class FirestoreService {
 
     final List<Task> out = [];
     for (final doc in snapshot.docs) {
-      final dec = await _enc.getDecrypted(ref: coll.doc(doc.id));
-      final data = dec ?? Map<String, dynamic>.from(doc.data());
+      final decrypted = await _enc.getDecrypted(ref: coll.doc(doc.id));
+      final data =
+          decrypted.isEmpty ? Map<String, dynamic>.from(doc.data()) : decrypted;
       out.add(Task.fromMap(data));
     }
     return out;
@@ -71,8 +72,9 @@ class FirestoreService {
 
     final List<Event> out = [];
     for (final doc in snapshot.docs) {
-      final dec = await _enc.getDecrypted(ref: coll.doc(doc.id));
-      final data = dec ?? Map<String, dynamic>.from(doc.data());
+      final decrypted = await _enc.getDecrypted(ref: coll.doc(doc.id));
+      final data =
+          decrypted.isEmpty ? Map<String, dynamic>.from(doc.data()) : decrypted;
       out.add(Event.fromMap(data));
     }
     return out;
@@ -97,8 +99,9 @@ class FirestoreService {
 
     final List<ScheduleItem> out = [];
     for (final doc in snapshot.docs) {
-      final dec = await _enc.getDecrypted(ref: coll.doc(doc.id));
-      final data = dec ?? Map<String, dynamic>.from(doc.data());
+      final decrypted = await _enc.getDecrypted(ref: coll.doc(doc.id));
+      final data =
+          decrypted.isEmpty ? Map<String, dynamic>.from(doc.data()) : decrypted;
       out.add(ScheduleItem.fromMap(data));
     }
     return out;
@@ -157,8 +160,9 @@ class FirestoreService {
 
     final List<Message> out = [];
     for (final doc in snapshot.docs) {
-      final dec = await _enc.getDecrypted(ref: coll.doc(doc.id));
-      final data = dec ?? Map<String, dynamic>.from(doc.data());
+      final decrypted = await _enc.getDecrypted(ref: coll.doc(doc.id));
+      final data =
+          decrypted.isEmpty ? Map<String, dynamic>.from(doc.data()) : decrypted;
       out.add(Message.fromMap(data));
     }
     return out;

--- a/FamilyAppFlutter/pubspec.lock
+++ b/FamilyAppFlutter/pubspec.lock
@@ -825,7 +825,7 @@ packages:
     source: hosted
     version: "2.1.8"
   pointycastle:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pointycastle
       sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"

--- a/FamilyAppFlutter/pubspec.yaml
+++ b/FamilyAppFlutter/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   encrypt: ^5.0.3
+  pointycastle: ^3.9.1
   flutter_secure_storage: ^9.0.0
   # For picking images from the gallery and camera
   image_picker: ^1.0.7


### PR DESCRIPTION
## Summary
- align task creation and scoreboard logic with the Task model and improve point calculations
- remove invalid null-aware usage across list screens and refresh AI suggestions styling to avoid deprecated APIs
- mark pointycastle as a direct dependency and harden Firestore decryption fallbacks

## Testing
- not run (flutter is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d1414c4808832b905d6021750a94c8