### PR TITLE
Restore full application navigation and features

### DIFF
--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -2,18 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
-import 'providers/family_data.dart';
 import 'providers/chat_provider.dart';
+import 'providers/family_data.dart';
 import 'providers/friends_data.dart';
 import 'providers/gallery_data.dart';
 import 'providers/schedule_data.dart';
-import 'screens/members_screen.dart';
+import 'screens/home_screen.dart';
 
-/// Entry point for the Family App.  Sets up providers and launches
-/// the root widget.  For demonstration purposes the home screen is
-/// the [MembersScreen]; navigation to other screens can be added
-/// as needed.
-void main() async {
+/// Entry point for the Family App. The root widget wires up all
+/// providers so the different feature screens can access shared state.
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
   final chatProvider = ChatProvider();
@@ -37,8 +35,12 @@ class MyApp extends StatelessWidget {
       ],
       child: MaterialApp(
         title: 'Family App',
-        theme: ThemeData.light(),
-        home: const MembersScreen(),
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+          useMaterial3: true,
+        ),
+        home: const HomeScreen(),
       ),
     );
   }

--- a/FamilyAppFlutter/lib/models/family_member.dart
+++ b/FamilyAppFlutter/lib/models/family_member.dart
@@ -1,4 +1,6 @@
 class FamilyMember {
+  static const _sentinel = Object();
+
   final String id;
   final String? name;
   final String? relationship;
@@ -71,4 +73,45 @@ class FamilyMember {
             .map((e) => e.map((k, v) => MapEntry(k.toString(), v?.toString() ?? '')))
             .toList(),
       );
+
+  FamilyMember copyWith({
+    Object? name = _sentinel,
+    Object? relationship = _sentinel,
+    Object? birthday = _sentinel,
+    Object? phone = _sentinel,
+    Object? email = _sentinel,
+    Object? avatarUrl = _sentinel,
+    Object? socialMedia = _sentinel,
+    Object? hobbies = _sentinel,
+    Object? documents = _sentinel,
+    Object? documentsList = _sentinel,
+    Object? socialNetworks = _sentinel,
+    Object? messengers = _sentinel,
+  }) {
+    return FamilyMember(
+      id: id,
+      name: name == _sentinel ? this.name : name as String?,
+      relationship:
+          relationship == _sentinel ? this.relationship : relationship as String?,
+      birthday: birthday == _sentinel ? this.birthday : birthday as DateTime?,
+      phone: phone == _sentinel ? this.phone : phone as String?,
+      email: email == _sentinel ? this.email : email as String?,
+      avatarUrl:
+          avatarUrl == _sentinel ? this.avatarUrl : avatarUrl as String?,
+      socialMedia: socialMedia == _sentinel
+          ? this.socialMedia
+          : socialMedia as String?,
+      hobbies: hobbies == _sentinel ? this.hobbies : hobbies as String?,
+      documents: documents == _sentinel ? this.documents : documents as String?,
+      documentsList: documentsList == _sentinel
+          ? this.documentsList
+          : documentsList as List<Map<String, String>>?,
+      socialNetworks: socialNetworks == _sentinel
+          ? this.socialNetworks
+          : socialNetworks as List<Map<String, String>>?,
+      messengers: messengers == _sentinel
+          ? this.messengers
+          : messengers as List<Map<String, String>>?,
+    );
+  }
 }

--- a/FamilyAppFlutter/lib/providers/family_data.dart
+++ b/FamilyAppFlutter/lib/providers/family_data.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/foundation.dart';
 
+import '../models/event.dart';
 import '../models/family_member.dart';
 import '../models/task.dart';
-import '../models/event.dart';
 
 /// Holds shared state for family members, tasks and events.  This
-/// provider exposes simple methods to add items and notifies
-/// listeners when changes occur.  More complex business logic can be
-/// added as the application grows.
+/// provider exposes methods to add and modify items and notifies
+/// listeners when changes occur.
 class FamilyData extends ChangeNotifier {
   /// All members in the family.
   final List<FamilyMember> members = [];
@@ -24,10 +23,57 @@ class FamilyData extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Returns the member with [id] or null if not found.
+  FamilyMember? memberById(String id) {
+    try {
+      return members.firstWhere((member) => member.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Updates an existing [member] if it is present in the list.
+  void updateMember(FamilyMember member) {
+    final index = members.indexWhere((m) => m.id == member.id);
+    if (index != -1) {
+      members[index] = member;
+      notifyListeners();
+    }
+  }
+
   /// Removes a [member] from the family and notifies listeners.
   void removeMember(FamilyMember member) {
-    members.remove(member);
+    members.removeWhere((m) => m.id == member.id);
     notifyListeners();
+  }
+
+  /// Removes a member by identifier.
+  void removeMemberById(String id) {
+    members.removeWhere((member) => member.id == id);
+    notifyListeners();
+  }
+
+  /// Updates the documents attached to a member.
+  void updateMemberDocuments(
+    String memberId, {
+    String? summary,
+    List<Map<String, String>>? documentsList,
+  }) {
+    final member = memberById(memberId);
+    if (member == null) return;
+    updateMember(
+      member.copyWith(
+        documents: summary,
+        documentsList: documentsList,
+      ),
+    );
+  }
+
+  /// Updates the hobbies stored for a member.
+  void updateMemberHobbies(String memberId, String? hobbies) {
+    final member = memberById(memberId);
+    if (member == null) return;
+    updateMember(member.copyWith(hobbies: hobbies));
   }
 
   /// Adds a [task] and notifies listeners.
@@ -36,9 +82,73 @@ class FamilyData extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Returns the task with [id] or null if not found.
+  Task? taskById(String id) {
+    try {
+      return tasks.firstWhere((task) => task.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Updates an existing task.
+  void updateTask(Task task) {
+    final index = tasks.indexWhere((t) => t.id == task.id);
+    if (index != -1) {
+      tasks[index] = task;
+      notifyListeners();
+    }
+  }
+
+  /// Removes a task by identifier.
+  void removeTask(String id) {
+    tasks.removeWhere((task) => task.id == id);
+    notifyListeners();
+  }
+
+  /// Updates the status of a task.
+  void updateTaskStatus(String id, TaskStatus status) {
+    final task = taskById(id);
+    if (task == null) return;
+    task.status = status;
+    notifyListeners();
+  }
+
+  /// Assigns a task to a member.
+  void assignTask(String id, String? assigneeId) {
+    final task = taskById(id);
+    if (task == null) return;
+    task.assigneeId = assigneeId;
+    notifyListeners();
+  }
+
   /// Adds an [event] and notifies listeners.
   void addEvent(Event event) {
     events.add(event);
+    notifyListeners();
+  }
+
+  /// Returns the event with [id] or null if not found.
+  Event? eventById(String id) {
+    try {
+      return events.firstWhere((event) => event.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Updates an existing event.
+  void updateEvent(Event event) {
+    final index = events.indexWhere((e) => e.id == event.id);
+    if (index != -1) {
+      events[index] = event;
+      notifyListeners();
+    }
+  }
+
+  /// Removes an event by identifier.
+  void removeEvent(String id) {
+    events.removeWhere((event) => event.id == id);
     notifyListeners();
   }
 }

--- a/FamilyAppFlutter/lib/providers/friends_data.dart
+++ b/FamilyAppFlutter/lib/providers/friends_data.dart
@@ -12,4 +12,9 @@ class FriendsData extends ChangeNotifier {
     friends.add(friend);
     notifyListeners();
   }
+
+  void removeFriend(String id) {
+    friends.removeWhere((friend) => friend.id == id);
+    notifyListeners();
+  }
 }

--- a/FamilyAppFlutter/lib/providers/gallery_data.dart
+++ b/FamilyAppFlutter/lib/providers/gallery_data.dart
@@ -11,4 +11,11 @@ class GalleryData extends ChangeNotifier {
     items.add(item);
     notifyListeners();
   }
+
+  void removeItem(String idOrUrl) {
+    items.removeWhere(
+      (item) => item.id == idOrUrl || item.url == idOrUrl,
+    );
+    notifyListeners();
+  }
 }

--- a/FamilyAppFlutter/lib/providers/schedule_data.dart
+++ b/FamilyAppFlutter/lib/providers/schedule_data.dart
@@ -12,4 +12,9 @@ class ScheduleData extends ChangeNotifier {
     items.add(item);
     notifyListeners();
   }
+
+  void removeItem(String id) {
+    items.removeWhere((item) => item.id == id);
+    notifyListeners();
+  }
 }

--- a/FamilyAppFlutter/lib/screens/add_chat_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_chat_screen.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/family_member.dart';
+import '../providers/chat_provider.dart';
+import '../providers/family_data.dart';
+
+class AddChatScreen extends StatefulWidget {
+  const AddChatScreen({super.key});
+
+  @override
+  State<AddChatScreen> createState() => _AddChatScreenState();
+}
+
+class _AddChatScreenState extends State<AddChatScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final Set<String> _selectedMemberIds = {};
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+    if (_selectedMemberIds.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Select at least one participant.')),
+      );
+      return;
+    }
+    final provider = context.read<ChatProvider>();
+    await provider.createChat(
+      title: _titleController.text.trim(),
+      memberIds: _selectedMemberIds.toList(),
+    );
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final members = context.watch<FamilyData>().members;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create chat')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(labelText: 'Chat title'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a title';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              Text('Participants', style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              if (members.isEmpty)
+                const Text('Add family members first to create a chat.')
+              else
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final FamilyMember member in members)
+                      FilterChip(
+                        label: Text(member.name ?? 'Unnamed'),
+                        selected: _selectedMemberIds.contains(member.id),
+                        onSelected: (selected) {
+                          setState(() {
+                            if (selected) {
+                              _selectedMemberIds.add(member.id);
+                            } else {
+                              _selectedMemberIds.remove(member.id);
+                            }
+                          });
+                        },
+                      ),
+                  ],
+                ),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _save,
+                  icon: const Icon(Icons.save),
+                  label: const Text('Create chat'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/screens/add_event_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_event_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../models/event.dart';
+import '../models/family_member.dart';
 import '../providers/family_data.dart';
 
-/// Screen for adding a new event.  Users may specify a title and
-/// optionally choose a date range.  Additional fields such as
-/// location or description could be added later.
+/// Screen for adding a new event.  Users may specify a title,
+/// description, date range and participants.
 class AddEventScreen extends StatefulWidget {
   const AddEventScreen({super.key});
 
@@ -15,111 +16,195 @@ class AddEventScreen extends StatefulWidget {
 }
 
 class _AddEventScreenState extends State<AddEventScreen> {
+  final _formKey = GlobalKey<FormState>();
   final _titleController = TextEditingController();
+  final _descriptionController = TextEditingController();
   DateTime? _startDate;
   DateTime? _endDate;
-
-  Future<void> _pickStartDate() async {
-    final now = DateTime.now();
-    final date = await showDatePicker(
-      context: context,
-      initialDate: _startDate ?? now,
-      firstDate: DateTime(now.year - 1),
-      lastDate: DateTime(now.year + 5),
-    );
-    if (date != null) {
-      setState(() {
-        _startDate = date;
-      });
-    }
-  }
-
-  Future<void> _pickEndDate() async {
-    final now = DateTime.now();
-    final date = await showDatePicker(
-      context: context,
-      initialDate: _endDate ?? _startDate ?? now,
-      firstDate: _startDate ?? now,
-      lastDate: DateTime(now.year + 5),
-    );
-    if (date != null) {
-      setState(() {
-        _endDate = date;
-      });
-    }
-  }
-
-  void _save() {
-    final title = _titleController.text.trim();
-    if (title.isEmpty) return;
-    final start = _startDate ?? DateTime.now();
-    final end = _endDate ??
-        (_startDate ?? DateTime.now()).add(const Duration(hours: 1));
-    final event = Event(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      title: title,
-      startDateTime: start,
-      endDateTime: end,
-    );
-    Provider.of<FamilyData>(context, listen: false).addEvent(event);
-    Navigator.of(context).pop();
-  }
+  final Set<String> _participantIds = {};
 
   @override
   void dispose() {
     _titleController.dispose();
+    _descriptionController.dispose();
     super.dispose();
+  }
+
+  Future<void> _pickStartDate() async {
+    final now = DateTime.now();
+    final initial = _startDate ?? now;
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(now.year - 1),
+      lastDate: DateTime(now.year + 5),
+    );
+    if (date == null) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(initial),
+    );
+    setState(() {
+      _startDate = DateTime(
+        date.year,
+        date.month,
+        date.day,
+        time?.hour ?? initial.hour,
+        time?.minute ?? initial.minute,
+      );
+      if (_endDate != null && _endDate!.isBefore(_startDate!)) {
+        _endDate = _startDate!.add(const Duration(hours: 1));
+      }
+    });
+  }
+
+  Future<void> _pickEndDate() async {
+    final now = DateTime.now();
+    final start = _startDate ?? now;
+    final initial = _endDate ?? start.add(const Duration(hours: 1));
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: start,
+      lastDate: DateTime(now.year + 5),
+    );
+    if (date == null) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(initial),
+    );
+    setState(() {
+      _endDate = DateTime(
+        date.year,
+        date.month,
+        date.day,
+        time?.hour ?? initial.hour,
+        time?.minute ?? initial.minute,
+      );
+    });
+  }
+
+  void _save() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    final title = _titleController.text.trim();
+    final description = _descriptionController.text.trim();
+    final start = _startDate ?? DateTime.now();
+    final end = (_endDate == null || _endDate!.isBefore(start))
+        ? start.add(const Duration(hours: 1))
+        : _endDate!;
+
+    final event = Event(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      title: title,
+      description: description.isEmpty ? null : description,
+      startDateTime: start,
+      endDateTime: end,
+      participantIds: _participantIds.toList(),
+    );
+
+    context.read<FamilyData>().addEvent(event);
+    Navigator.of(context).pop();
   }
 
   @override
   Widget build(BuildContext context) {
+    final members = context.watch<FamilyData>().members;
     return Scaffold(
       appBar: AppBar(title: const Text('Add Event')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              TextField(
-                controller: _titleController,
-                decoration: const InputDecoration(labelText: 'Title'),
-              ),
-              const SizedBox(height: 20),
-              Row(
-                children: [
-                  Expanded(
-                    child: ElevatedButton(
-                      onPressed: _pickStartDate,
-                      child: Text(
-                        _startDate == null
-                            ? 'Select start date'
-                            : 'Start: ${_startDate!.toLocal().toString().split(' ')[0]}',
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _titleController,
+                  decoration: const InputDecoration(labelText: 'Title'),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter a title';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _descriptionController,
+                  decoration: const InputDecoration(labelText: 'Description'),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: _pickStartDate,
+                        child: Text(
+                          _startDate == null
+                              ? 'Select start'
+                              : 'Start: ${_formatDate(_startDate!)}',
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: ElevatedButton(
-                      onPressed: _pickEndDate,
-                      child: Text(
-                        _endDate == null
-                            ? 'Select end date'
-                            : 'End: ${_endDate!.toLocal().toString().split(' ')[0]}',
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: _pickEndDate,
+                        child: Text(
+                          _endDate == null
+                              ? 'Select end'
+                              : 'End: ${_formatDate(_endDate!)}',
+                        ),
                       ),
                     ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Text('Participants', style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 8),
+                if (members.isEmpty)
+                  const Text('Add family members to assign participants.')
+                else
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final FamilyMember member in members)
+                        FilterChip(
+                          label: Text(member.name ?? 'Unnamed'),
+                          selected: _participantIds.contains(member.id),
+                          onSelected: (selected) {
+                            setState(() {
+                              if (selected) {
+                                _participantIds.add(member.id);
+                              } else {
+                                _participantIds.remove(member.id);
+                              }
+                            });
+                          },
+                        ),
+                    ],
                   ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: _save,
-                child: const Text('Save'),
-              ),
-            ],
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _save,
+                    icon: const Icon(Icons.save),
+                    label: const Text('Save event'),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
+
+  String _formatDate(DateTime date) => DateFormat('dd.MM.yyyy HH:mm').format(date);
 }

--- a/FamilyAppFlutter/lib/screens/add_friend_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_friend_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/friend.dart';
+import '../providers/friends_data.dart';
+
+class AddFriendScreen extends StatefulWidget {
+  const AddFriendScreen({super.key});
+
+  @override
+  State<AddFriendScreen> createState() => _AddFriendScreenState();
+}
+
+class _AddFriendScreenState extends State<AddFriendScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _uuid = const Uuid();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+    final friend = Friend(
+      id: _uuid.v4(),
+      name: _nameController.text.trim(),
+    );
+    context.read<FriendsData>().addFriend(friend);
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add friend')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a name';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _save,
+                  icon: const Icon(Icons.save),
+                  label: const Text('Save'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/gallery_item.dart';
+import '../providers/gallery_data.dart';
+
+class AddGalleryItemScreen extends StatefulWidget {
+  const AddGalleryItemScreen({super.key});
+
+  @override
+  State<AddGalleryItemScreen> createState() => _AddGalleryItemScreenState();
+}
+
+class _AddGalleryItemScreenState extends State<AddGalleryItemScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _urlController = TextEditingController();
+  final _uuid = const Uuid();
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    final url = _urlController.text.trim();
+    final item = GalleryItem(
+      id: _uuid.v4(),
+      url: url,
+    );
+    context.read<GalleryData>().addItem(item);
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add gallery item')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _urlController,
+                decoration: const InputDecoration(
+                  labelText: 'Image URL',
+                  hintText: 'https://example.com/photo.jpg',
+                ),
+                keyboardType: TextInputType.url,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a URL';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _save,
+                  icon: const Icon(Icons.save),
+                  label: const Text('Save'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/screens/add_member_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_member_screen.dart
@@ -1,58 +1,222 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../models/family_member.dart';
 import '../providers/family_data.dart';
 
-/// Screen for adding a new family member.  Provides a simple form
-/// containing a text field for the name and saves the member via
-/// [FamilyData] when submitted.
+/// Screen for adding or editing a family member.  Provides a detailed
+/// form so contact information and other metadata can be captured.
 class AddMemberScreen extends StatefulWidget {
-  const AddMemberScreen({super.key});
+  final FamilyMember? initialMember;
+  const AddMemberScreen({super.key, this.initialMember});
 
   @override
   State<AddMemberScreen> createState() => _AddMemberScreenState();
 }
 
 class _AddMemberScreenState extends State<AddMemberScreen> {
+  final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
+  final _relationshipController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _avatarUrlController = TextEditingController();
+  final _socialMediaController = TextEditingController();
+  final _hobbiesController = TextEditingController();
+  final _documentsController = TextEditingController();
+
+  DateTime? _birthday;
+
+  @override
+  void initState() {
+    super.initState();
+    final member = widget.initialMember;
+    if (member != null) {
+      _nameController.text = member.name ?? '';
+      _relationshipController.text = member.relationship ?? '';
+      _phoneController.text = member.phone ?? '';
+      _emailController.text = member.email ?? '';
+      _avatarUrlController.text = member.avatarUrl ?? '';
+      _socialMediaController.text = member.socialMedia ?? '';
+      _hobbiesController.text = member.hobbies ?? '';
+      _documentsController.text = member.documents ?? '';
+      _birthday = member.birthday;
+    }
+  }
+
+  Future<void> _pickBirthday() async {
+    final now = DateTime.now();
+    final initialDate = _birthday ?? DateTime(now.year - 10, now.month, now.day);
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: DateTime(now.year - 120),
+      lastDate: DateTime(now.year + 5),
+    );
+    if (date != null) {
+      setState(() {
+        _birthday = date;
+      });
+    }
+  }
 
   void _save() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
     final name = _nameController.text.trim();
-    if (name.isEmpty) return;
+    final relationship = _relationshipController.text.trim();
+    final phone = _phoneController.text.trim();
+    final email = _emailController.text.trim();
+    final avatarUrl = _avatarUrlController.text.trim();
+    final socialMedia = _socialMediaController.text.trim();
+    final hobbies = _hobbiesController.text.trim();
+    final documents = _documentsController.text.trim();
+
+    final existing = widget.initialMember;
     final member = FamilyMember(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      id: existing?.id ?? DateTime.now().millisecondsSinceEpoch.toString(),
       name: name,
+      relationship: relationship.isEmpty ? null : relationship,
+      birthday: _birthday,
+      phone: phone.isEmpty ? null : phone,
+      email: email.isEmpty ? null : email,
+      avatarUrl: avatarUrl.isEmpty ? null : avatarUrl,
+      socialMedia: socialMedia.isEmpty ? null : socialMedia,
+      hobbies: hobbies.isEmpty ? null : hobbies,
+      documents: documents.isEmpty ? null : documents,
+      documentsList: existing?.documentsList,
+      socialNetworks: existing?.socialNetworks,
+      messengers: existing?.messengers,
     );
-    Provider.of<FamilyData>(context, listen: false).addMember(member);
+
+    final familyData = Provider.of<FamilyData>(context, listen: false);
+    if (existing == null) {
+      familyData.addMember(member);
+    } else {
+      familyData.updateMember(member);
+    }
     Navigator.of(context).pop();
   }
 
   @override
   void dispose() {
     _nameController.dispose();
+    _relationshipController.dispose();
+    _phoneController.dispose();
+    _emailController.dispose();
+    _avatarUrlController.dispose();
+    _socialMediaController.dispose();
+    _hobbiesController.dispose();
+    _documentsController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final isEditing = widget.initialMember != null;
+    final theme = Theme.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Add Member')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: _nameController,
-              decoration: const InputDecoration(labelText: 'Name'),
+      appBar: AppBar(title: Text(isEditing ? 'Edit Member' : 'Add Member')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                  textCapitalization: TextCapitalization.words,
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter a name';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _relationshipController,
+                  decoration: const InputDecoration(labelText: 'Relationship'),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        _birthday == null
+                            ? 'Birthday not set'
+                            : 'Birthday: ${DateFormat('dd.MM.yyyy').format(_birthday!)}',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                    TextButton.icon(
+                      onPressed: _pickBirthday,
+                      icon: const Icon(Icons.cake_outlined),
+                      label: const Text('Select date'),
+                    ),
+                  ],
+                ),
+                const Divider(height: 32),
+                Text('Contacts', style: theme.textTheme.titleMedium),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: _phoneController,
+                  decoration: const InputDecoration(labelText: 'Phone'),
+                  keyboardType: TextInputType.phone,
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _emailController,
+                  decoration: const InputDecoration(labelText: 'Email'),
+                  keyboardType: TextInputType.emailAddress,
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _avatarUrlController,
+                  decoration: const InputDecoration(labelText: 'Avatar URL'),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _socialMediaController,
+                  decoration: const InputDecoration(labelText: 'Social networks'),
+                ),
+                const Divider(height: 32),
+                Text('Additional info', style: theme.textTheme.titleMedium),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: _hobbiesController,
+                  decoration: const InputDecoration(
+                    labelText: 'Hobbies',
+                    hintText: 'e.g. football, painting',
+                  ),
+                  maxLines: 2,
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _documentsController,
+                  decoration: const InputDecoration(
+                    labelText: 'Important documents',
+                    hintText: 'Passport, insurance, etc.',
+                  ),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: _save,
+                    icon: const Icon(Icons.save),
+                    label: Text(isEditing ? 'Save changes' : 'Add member'),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _save,
-              child: const Text('Save'),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/family_member.dart';
+import '../models/schedule_item.dart';
+import '../providers/family_data.dart';
+import '../providers/schedule_data.dart';
+
+class AddScheduleItemScreen extends StatefulWidget {
+  const AddScheduleItemScreen({super.key});
+
+  @override
+  State<AddScheduleItemScreen> createState() => _AddScheduleItemScreenState();
+}
+
+class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _locationController = TextEditingController();
+  final _notesController = TextEditingController();
+
+  DateTime? _dateTime;
+  Duration? _duration;
+  String? _memberId;
+
+  final List<Duration> _durationOptions = const [
+    Duration(minutes: 30),
+    Duration(hours: 1),
+    Duration(hours: 2),
+    Duration(hours: 3),
+  ];
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _locationController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDateTime() async {
+    final now = DateTime.now();
+    final initial = _dateTime ?? now;
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(now.year - 1),
+      lastDate: DateTime(now.year + 5),
+    );
+    if (date == null) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(initial),
+    );
+    if (!mounted) return;
+    setState(() {
+      _dateTime = DateTime(
+        date.year,
+        date.month,
+        date.day,
+        time?.hour ?? initial.hour,
+        time?.minute ?? initial.minute,
+      );
+    });
+  }
+
+  void _save() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    final title = _titleController.text.trim();
+    final location = _locationController.text.trim();
+    final notes = _notesController.text.trim();
+    final dateTime = _dateTime ?? DateTime.now();
+
+    final item = ScheduleItem(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      title: title,
+      dateTime: dateTime,
+      duration: _duration,
+      location: location.isEmpty ? null : location,
+      notes: notes.isEmpty ? null : notes,
+      memberId: _memberId,
+    );
+
+    context.read<ScheduleData>().addItem(item);
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final members = context.watch<FamilyData>().members;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add schedule item')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _titleController,
+                  decoration: const InputDecoration(labelText: 'Title'),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter a title';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Date & time'),
+                  subtitle: Text(
+                    _dateTime == null
+                        ? 'Not set'
+                        : DateFormat('dd.MM.yyyy HH:mm').format(_dateTime!),
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.schedule),
+                    onPressed: _pickDateTime,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<Duration?>(
+                  value: _duration,
+                  decoration: const InputDecoration(labelText: 'Duration'),
+                  items: [
+                    const DropdownMenuItem<Duration?>(
+                      value: null,
+                      child: Text('Not specified'),
+                    ),
+                    ..._durationOptions.map(
+                      (duration) => DropdownMenuItem<Duration?>(
+                        value: duration,
+                        child: Text('${duration.inMinutes} minutes'),
+                      ),
+                    ),
+                  ],
+                  onChanged: (value) => setState(() => _duration = value),
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<String?>(
+                  value: _memberId,
+                  decoration: const InputDecoration(labelText: 'Assign to member'),
+                  items: [
+                    const DropdownMenuItem<String?>(
+                      value: null,
+                      child: Text('No member'),
+                    ),
+                    ...members.map(
+                      (FamilyMember member) => DropdownMenuItem<String?>(
+                        value: member.id,
+                        child: Text(member.name ?? 'Unnamed'),
+                      ),
+                    ),
+                  ],
+                  onChanged: (value) => setState(() => _memberId = value),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _locationController,
+                  decoration: const InputDecoration(labelText: 'Location'),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _notesController,
+                  decoration: const InputDecoration(labelText: 'Notes'),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _save,
+                    icon: const Icon(Icons.save),
+                    label: const Text('Save item'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/screens/add_task_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_task_screen.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../models/task.dart';
 import '../providers/family_data.dart';
 
-/// Screen for adding a new task.  Users can provide a title; other
-/// properties such as description or due date could be added later.
+/// Screen for adding a new task.  Users can provide title, description,
+/// due date, assignee and status.
 class AddTaskScreen extends StatefulWidget {
   const AddTaskScreen({super.key});
 
@@ -14,46 +15,171 @@ class AddTaskScreen extends StatefulWidget {
 }
 
 class _AddTaskScreenState extends State<AddTaskScreen> {
+  final _formKey = GlobalKey<FormState>();
   final _titleController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _pointsController = TextEditingController();
+
+  DateTime? _dueDate;
+  TaskStatus _status = TaskStatus.todo;
+  String? _assigneeId;
+
+  Future<void> _pickDueDate() async {
+    final now = DateTime.now();
+    final initialDate = _dueDate ?? now;
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: DateTime(now.year - 1),
+      lastDate: DateTime(now.year + 5),
+    );
+    if (date == null) return;
+    final timeOfDay = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_dueDate ?? now),
+    );
+    setState(() {
+      _dueDate = DateTime(
+        date.year,
+        date.month,
+        date.day,
+        timeOfDay?.hour ?? initialDate.hour,
+        timeOfDay?.minute ?? initialDate.minute,
+      );
+    });
+  }
 
   void _save() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) {
+      return;
+    }
     final title = _titleController.text.trim();
-    if (title.isEmpty) return;
+    final description = _descriptionController.text.trim();
+    final pointsValue = int.tryParse(_pointsController.text.trim());
+
     final task = Task(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       title: title,
-      status: TaskStatus.todo,
-      points: 0,
+      description: description.isEmpty ? null : description,
+      dueDate: _dueDate,
+      status: _status,
+      assigneeId: _assigneeId,
+      points: pointsValue,
     );
-    Provider.of<FamilyData>(context, listen: false).addTask(task);
+
+    context.read<FamilyData>().addTask(task);
     Navigator.of(context).pop();
   }
 
   @override
   void dispose() {
     _titleController.dispose();
+    _descriptionController.dispose();
+    _pointsController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final members = context.watch<FamilyData>().members;
     return Scaffold(
       appBar: AppBar(title: const Text('Add Task')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: _titleController,
-              decoration: const InputDecoration(labelText: 'Title'),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextFormField(
+                  controller: _titleController,
+                  decoration: const InputDecoration(labelText: 'Title'),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Please enter a title';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _descriptionController,
+                  decoration: const InputDecoration(labelText: 'Description'),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 12),
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Due date'),
+                  subtitle: Text(
+                    _dueDate == null
+                        ? 'Not set'
+                        : DateFormat('dd.MM.yyyy HH:mm').format(_dueDate!),
+                  ),
+                  trailing: IconButton(
+                    onPressed: _pickDueDate,
+                    icon: const Icon(Icons.calendar_today),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<TaskStatus>(
+                  value: _status,
+                  decoration: const InputDecoration(labelText: 'Status'),
+                  items: TaskStatus.values
+                      .map(
+                        (status) => DropdownMenuItem(
+                          value: status,
+                          child: Text(status.name),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (value) {
+                    if (value != null) {
+                      setState(() => _status = value);
+                    }
+                  },
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<String?>(
+                  value: _assigneeId,
+                  decoration: const InputDecoration(labelText: 'Assign to'),
+                  items: [
+                    const DropdownMenuItem<String?>(
+                      value: null,
+                      child: Text('Unassigned'),
+                    ),
+                    ...members.map(
+                      (member) => DropdownMenuItem<String?>(
+                        value: member.id,
+                        child: Text(member.name ?? 'Unnamed'),
+                      ),
+                    ),
+                  ],
+                  onChanged: (value) => setState(() => _assigneeId = value),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _pointsController,
+                  decoration: const InputDecoration(
+                    labelText: 'Reward points',
+                    hintText: 'Optional integer value',
+                  ),
+                  keyboardType: TextInputType.number,
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _save,
+                    icon: const Icon(Icons.save),
+                    label: const Text('Save'),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _save,
-              child: const Text('Save'),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/FamilyAppFlutter/lib/screens/call_setup_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_setup_screen.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/conversation.dart';
+import '../models/family_member.dart';
+import '../providers/family_data.dart';
+import 'call_screen.dart';
+
+class CallSetupScreen extends StatefulWidget {
+  const CallSetupScreen({super.key});
+
+  @override
+  State<CallSetupScreen> createState() => _CallSetupScreenState();
+}
+
+class _CallSetupScreenState extends State<CallSetupScreen> {
+  final _titleController = TextEditingController(text: 'Family call');
+  String _callType = 'audio';
+  final Set<String> _selectedMemberIds = {};
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  void _startCall(List<FamilyMember> members) {
+    final selected = _selectedMemberIds.isNotEmpty
+        ? _selectedMemberIds.toList()
+        : members.map((member) => member.id).toList();
+    if (selected.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Select at least one participant.')),
+      );
+      return;
+    }
+    final title = _titleController.text.trim().isEmpty
+        ? 'Call'
+        : _titleController.text.trim();
+    final conversation = Conversation(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      title: title,
+      memberIds: selected,
+      createdAt: DateTime.now(),
+    );
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CallScreen(
+          conversation: conversation,
+          callType: _callType,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final members = context.watch<FamilyData>().members;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Start a call')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'Call title'),
+            ),
+            const SizedBox(height: 16),
+            Text('Call type', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            SegmentedButton<String>(
+              segments: const [
+                ButtonSegment(value: 'audio', label: Text('Audio'), icon: Icon(Icons.call)),
+                ButtonSegment(value: 'video', label: Text('Video'), icon: Icon(Icons.videocam)),
+              ],
+              selected: <String>{_callType},
+              onSelectionChanged: (selection) {
+                setState(() => _callType = selection.first);
+              },
+            ),
+            const SizedBox(height: 24),
+            Text('Participants', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            if (members.isEmpty)
+              const Text('Add family members to start a call.')
+            else
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final member in members)
+                    FilterChip(
+                      label: Text(member.name ?? 'Unnamed'),
+                      selected: _selectedMemberIds.contains(member.id),
+                      onSelected: (selected) {
+                        setState(() {
+                          if (selected) {
+                            _selectedMemberIds.add(member.id);
+                          } else {
+                            _selectedMemberIds.remove(member.id);
+                          }
+                        });
+                      },
+                    ),
+                ],
+              ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: () => _startCall(members),
+                icon: const Icon(Icons.play_arrow),
+                label: const Text('Start call'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/screens/chat_list_screen.dart
+++ b/FamilyAppFlutter/lib/screens/chat_list_screen.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-/// Placeholder screen showing a list of chat conversations.  This
-/// simplified version displays static text and can be expanded to
-/// integrate with [ChatProvider] or [ChatData].
+import '../models/chat.dart';
+import '../providers/chat_provider.dart';
+import '../providers/family_data.dart';
+import 'add_chat_screen.dart';
+import 'chat_screen.dart';
+
+/// Displays a list of chat conversations backed by [ChatProvider].
 class ChatListScreen extends StatelessWidget {
   const ChatListScreen({super.key});
 
@@ -10,7 +15,52 @@ class ChatListScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Chats')),
-      body: const Center(child: Text('No chats available.')),
+      body: Consumer2<ChatProvider, FamilyData>(
+        builder: (context, chatProvider, familyData, _) {
+          final List<Chat> chats = chatProvider.chats;
+          if (chats.isEmpty) {
+            return const Center(child: Text('No chats available.'));
+          }
+          return ListView.separated(
+            itemCount: chats.length,
+            separatorBuilder: (_, __) => const Divider(height: 0),
+            itemBuilder: (context, index) {
+              final chat = chats[index];
+              final participantNames = chat.memberIds
+                  .map((id) => familyData.memberById(id)?.name ?? 'Unknown')
+                  .join(', ');
+              return ListTile(
+                leading: const Icon(Icons.chat_bubble_outline),
+                title: Text(chat.title),
+                subtitle: Text(
+                  chat.lastMessagePreview?.isNotEmpty == true
+                      ? chat.lastMessagePreview!
+                      : 'Participants: $participantNames',
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: () => chatProvider.deleteChat(chat.id),
+                ),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => ChatScreen(chat: chat),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const AddChatScreen()),
+          );
+        },
+        child: const Icon(Icons.add_comment),
+      ),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/chat_screen.dart
+++ b/FamilyAppFlutter/lib/screens/chat_screen.dart
@@ -1,21 +1,161 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
 import '../models/chat.dart';
+import '../models/chat_message.dart';
+import '../providers/chat_provider.dart';
+import '../providers/family_data.dart';
 
-/// Displays a single chat conversation.  This placeholder implementation
-/// shows only the chat title and a message indicating that no
-/// messages are present.  Integrate with [ChatProvider] to show
-/// messages.
-class ChatScreen extends StatelessWidget {
+/// Displays a single chat conversation with the ability to send
+/// messages via [ChatProvider].
+class ChatScreen extends StatefulWidget {
   final Chat chat;
 
   const ChatScreen({super.key, required this.chat});
 
   @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  final _messageController = TextEditingController();
+  String? _selectedSenderId;
+
+  @override
+  void initState() {
+    super.initState();
+    final memberIds = widget.chat.memberIds.map((id) => id.toString()).toList();
+    if (memberIds.isNotEmpty) {
+      _selectedSenderId = memberIds.first;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<ChatProvider>().markRead(widget.chat.id);
+    });
+  }
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _messageController.text.trim();
+    final senderId = _selectedSenderId;
+    if (text.isEmpty || senderId == null) return;
+    await context
+        .read<ChatProvider>()
+        .sendText(chatId: widget.chat.id, senderId: senderId, text: text);
+    _messageController.clear();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(chat.title)),
-      body: const Center(child: Text('No messages yet.')),
+      appBar: AppBar(title: Text(widget.chat.title)),
+      body: Consumer2<ChatProvider, FamilyData>(
+        builder: (context, chatProvider, familyData, _) {
+          final messages = chatProvider.messagesByChat(widget.chat.id);
+          final members = familyData.members;
+          if (_selectedSenderId == null) {
+            if (widget.chat.memberIds.isNotEmpty) {
+              _selectedSenderId = widget.chat.memberIds.first.toString();
+            } else if (members.isNotEmpty) {
+              _selectedSenderId = members.first.id;
+            }
+          }
+
+          return Column(
+            children: [
+              Expanded(
+                child: messages.isEmpty
+                    ? const Center(child: Text('No messages yet.'))
+                    : ListView.separated(
+                        padding: const EdgeInsets.all(16),
+                        itemCount: messages.length,
+                        separatorBuilder: (_, __) => const SizedBox(height: 8),
+                        itemBuilder: (context, index) {
+                          final ChatMessage message = messages[index];
+                          final senderName =
+                              familyData.memberById(message.senderId)?.name ?? 'Unknown';
+                          return Align(
+                            alignment: Alignment.centerLeft,
+                            child: Container(
+                              padding: const EdgeInsets.all(12),
+                              decoration: BoxDecoration(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .primary
+                                    .withValues(alpha: 0.1),
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    senderName,
+                                    style: Theme.of(context).textTheme.labelMedium,
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(message.content),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    DateFormat('dd.MM.yyyy HH:mm').format(message.createdAt),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .labelSmall
+                                        ?.copyWith(color: Theme.of(context).hintColor),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Row(
+                  children: [
+                    DropdownButton<String>(
+                      value: _selectedSenderId,
+                      hint: const Text('Sender'),
+                      items: [
+                        for (final member in members)
+                          DropdownMenuItem<String>(
+                            value: member.id,
+                            child: Text(member.name ?? 'Unnamed'),
+                          ),
+                      ],
+                      onChanged: (value) {
+                        setState(() => _selectedSenderId = value);
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextField(
+                        controller: _messageController,
+                        decoration: const InputDecoration(
+                          hintText: 'Type a message',
+                          border: OutlineInputBorder(),
+                        ),
+                        minLines: 1,
+                        maxLines: 3,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.send),
+                      onPressed: _sendMessage,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/edit_documents_screen.dart
+++ b/FamilyAppFlutter/lib/screens/edit_documents_screen.dart
@@ -1,15 +1,179 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-/// Allows users to edit member documents.  In this simplified version
-/// no editing functionality is provided.
-class EditDocumentsScreen extends StatelessWidget {
-  const EditDocumentsScreen({super.key});
+import '../models/family_member.dart';
+import '../providers/family_data.dart';
+
+/// Allows users to edit member documents.
+class EditDocumentsScreen extends StatefulWidget {
+  final FamilyMember member;
+  const EditDocumentsScreen({super.key, required this.member});
+
+  @override
+  State<EditDocumentsScreen> createState() => _EditDocumentsScreenState();
+}
+
+class _EditDocumentsScreenState extends State<EditDocumentsScreen> {
+  final _summaryController = TextEditingController();
+  final List<_DocumentControllers> _documents = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _summaryController.text = widget.member.documents ?? '';
+    final docs = widget.member.documentsList ?? const <Map<String, String>>[];
+    if (docs.isEmpty) {
+      _addDocument();
+    } else {
+      for (final doc in docs) {
+        _documents.add(
+          _DocumentControllers(
+            title: TextEditingController(text: doc['title'] ?? doc['name'] ?? ''),
+            value: TextEditingController(text: doc['description'] ?? doc['value'] ?? ''),
+          ),
+        );
+      }
+    }
+  }
+
+  void _addDocument() {
+    setState(() {
+      _documents.add(
+        _DocumentControllers(
+          title: TextEditingController(),
+          value: TextEditingController(),
+        ),
+      );
+    });
+  }
+
+  void _removeDocument(int index) {
+    setState(() {
+      _documents.removeAt(index);
+      if (_documents.isEmpty) {
+        _addDocument();
+      }
+    });
+  }
+
+  void _save() {
+    final summary = _summaryController.text.trim();
+    final docs = <Map<String, String>>[];
+    for (final doc in _documents) {
+      final title = doc.title.text.trim();
+      final value = doc.value.text.trim();
+      if (title.isEmpty && value.isEmpty) {
+        continue;
+      }
+      docs.add({
+        'title': title,
+        'description': value,
+      });
+    }
+    context.read<FamilyData>().updateMemberDocuments(
+          widget.member.id,
+          summary: summary.isEmpty ? null : summary,
+          documentsList: docs.isEmpty ? null : docs,
+        );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  void dispose() {
+    _summaryController.dispose();
+    for (final doc in _documents) {
+      doc.dispose();
+    }
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Edit Documents')),
-      body: const Center(child: Text('Document editing is not implemented.')),
+      appBar: AppBar(title: Text('Edit documents – ${widget.member.name ?? ''}'.trim())),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              TextField(
+                controller: _summaryController,
+                decoration: const InputDecoration(
+                  labelText: 'Summary',
+                  hintText: 'General notes about documents',
+                ),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: ListView.builder(
+                  itemCount: _documents.length,
+                  itemBuilder: (context, index) {
+                    final doc = _documents[index];
+                    return Card(
+                      margin: const EdgeInsets.only(bottom: 12),
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            TextField(
+                              controller: doc.title,
+                              decoration: const InputDecoration(labelText: 'Document title'),
+                            ),
+                            const SizedBox(height: 8),
+                            TextField(
+                              controller: doc.value,
+                              decoration: const InputDecoration(labelText: 'Details / description'),
+                              maxLines: 2,
+                            ),
+                            Align(
+                              alignment: Alignment.centerRight,
+                              child: IconButton(
+                                onPressed: () => _removeDocument(index),
+                                icon: const Icon(Icons.delete_outline),
+                                tooltip: 'Remove',
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  OutlinedButton.icon(
+                    onPressed: _addDocument,
+                    icon: const Icon(Icons.add),
+                    label: const Text('Add document'),
+                  ),
+                  const Spacer(),
+                  FilledButton.icon(
+                    onPressed: _save,
+                    icon: const Icon(Icons.save),
+                    label: const Text('Save'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
+  }
+}
+
+class _DocumentControllers {
+  final TextEditingController title;
+  final TextEditingController value;
+
+  _DocumentControllers({required this.title, required this.value});
+
+  void dispose() {
+    title.dispose();
+    value.dispose();
   }
 }

--- a/FamilyAppFlutter/lib/screens/edit_hobbies_screen.dart
+++ b/FamilyAppFlutter/lib/screens/edit_hobbies_screen.dart
@@ -1,15 +1,69 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-/// Allows users to edit a member's hobbies.  This stub screen
-/// currently shows a placeholder message.
-class EditHobbiesScreen extends StatelessWidget {
-  const EditHobbiesScreen({super.key});
+import '../models/family_member.dart';
+import '../providers/family_data.dart';
+
+/// Allows users to edit a member's hobbies.
+class EditHobbiesScreen extends StatefulWidget {
+  final FamilyMember member;
+  const EditHobbiesScreen({super.key, required this.member});
+
+  @override
+  State<EditHobbiesScreen> createState() => _EditHobbiesScreenState();
+}
+
+class _EditHobbiesScreenState extends State<EditHobbiesScreen> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.member.hobbies ?? '');
+  }
+
+  void _save() {
+    final hobbies = _controller.text.trim();
+    context
+        .read<FamilyData>()
+        .updateMemberHobbies(widget.member.id, hobbies.isEmpty ? null : hobbies);
+    Navigator.of(context).pop();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Edit Hobbies')),
-      body: const Center(child: Text('Hobby editing is not implemented.')),
+      appBar: AppBar(title: Text('Edit hobbies – ${widget.member.name ?? ''}'.trim())),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(
+                labelText: 'Hobbies',
+                hintText: 'Describe hobbies, interests and skills',
+              ),
+              maxLines: 5,
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _save,
+                icon: const Icon(Icons.save),
+                label: const Text('Save'),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/events_screen.dart
+++ b/FamilyAppFlutter/lib/screens/events_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../providers/family_data.dart';
 import '../models/event.dart';
+import '../providers/family_data.dart';
 import 'add_event_screen.dart';
 
-/// Shows all events in the family calendar.  Users can view basic
-/// event information and add new events using the floating action
-/// button.
+/// Shows all events in the family calendar.  Users can view event
+/// information and add new events using the floating action button.
 class EventsScreen extends StatelessWidget {
   const EventsScreen({super.key});
 
@@ -21,14 +21,42 @@ class EventsScreen extends StatelessWidget {
           if (events.isEmpty) {
             return const Center(child: Text('No events added yet.'));
           }
-          return ListView.builder(
+          events.sort((a, b) => a.startDateTime.compareTo(b.startDateTime));
+          return ListView.separated(
+            padding: const EdgeInsets.all(12),
             itemCount: events.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
             itemBuilder: (context, index) {
               final event = events[index];
-              return ListTile(
-                leading: const Icon(Icons.event),
-                title: Text(event.title),
-                subtitle: Text(event.startDateTime.toString()),
+              final participants = event.participantIds
+                  .map((id) => data.memberById(id)?.name ?? 'Unknown member')
+                  .toList();
+              return Card(
+                child: ListTile(
+                  leading: const Icon(Icons.event),
+                  title: Text(event.title),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(_formatRange(event.startDateTime, event.endDateTime)),
+                      if (event.description?.isNotEmpty == true)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(event.description!),
+                        ),
+                      if (participants.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text('Participants: ${participants.join(', ')}'),
+                        ),
+                    ],
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    tooltip: 'Delete event',
+                    onPressed: () => _confirmDelete(context, event),
+                  ),
+                ),
               );
             },
           );
@@ -41,6 +69,34 @@ class EventsScreen extends StatelessWidget {
           );
         },
         child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  String _formatRange(DateTime start, DateTime end) {
+    final formatter = DateFormat('dd.MM.yyyy HH:mm');
+    return '${formatter.format(start)} – ${formatter.format(end)}';
+  }
+
+  void _confirmDelete(BuildContext context, Event event) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete event'),
+        content: Text('Delete "${event.title}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              context.read<FamilyData>().removeEvent(event.id);
+              Navigator.of(ctx).pop();
+            },
+            child: const Text('Delete'),
+          ),
+        ],
       ),
     );
   }

--- a/FamilyAppFlutter/lib/screens/friends_screen.dart
+++ b/FamilyAppFlutter/lib/screens/friends_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../providers/friends_data.dart';
 import '../models/friend.dart';
+import '../providers/friends_data.dart';
+import 'add_friend_screen.dart';
 
-/// Shows a list of friends.  Friends can be added elsewhere in the
-/// application; this screen simply displays them.
+/// Shows a list of friends with the ability to add and remove entries.
 class FriendsScreen extends StatelessWidget {
   const FriendsScreen({super.key});
 
@@ -18,17 +18,35 @@ class FriendsScreen extends StatelessWidget {
           if (data.friends.isEmpty) {
             return const Center(child: Text('No friends added.'));
           }
-          return ListView.builder(
+          return ListView.separated(
             itemCount: data.friends.length,
+            separatorBuilder: (_, __) => const Divider(height: 0),
             itemBuilder: (context, index) {
               final Friend friend = data.friends[index];
               return ListTile(
                 leading: const Icon(Icons.person),
                 title: Text(friend.name ?? ''),
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: () {
+                    final id = friend.id;
+                    if (id != null) {
+                      context.read<FriendsData>().removeFriend(id);
+                    }
+                  },
+                ),
               );
             },
           );
         },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const AddFriendScreen()),
+          );
+        },
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/FamilyAppFlutter/lib/screens/gallery_screen.dart
+++ b/FamilyAppFlutter/lib/screens/gallery_screen.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../providers/gallery_data.dart';
 import '../models/gallery_item.dart';
+import '../providers/gallery_data.dart';
+import 'add_gallery_item_screen.dart';
 
-/// Displays a grid of gallery items.  Each item simply shows the URL
-/// text in this stub; images could be displayed using a network
-/// image widget in a real implementation.
+/// Displays a grid of gallery items and allows adding/removing entries.
 class GalleryScreen extends StatelessWidget {
   const GalleryScreen({super.key});
 
@@ -29,16 +28,44 @@ class GalleryScreen extends StatelessWidget {
             itemCount: data.items.length,
             itemBuilder: (context, index) {
               final GalleryItem item = data.items[index];
-              return Container(
-                padding: const EdgeInsets.all(8),
-                color: Colors.grey.shade200,
-                child: Center(
-                  child: Text(item.url ?? ''),
-                ),
+              return Stack(
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade200,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    alignment: Alignment.center,
+                    padding: const EdgeInsets.all(8),
+                    child: Text(
+                      item.url ?? 'No URL',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    right: 0,
+                    child: IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () {
+                        final id = item.id ?? item.url ?? '';
+                        context.read<GalleryData>().removeItem(id);
+                      },
+                    ),
+                  ),
+                ],
               );
             },
           );
         },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const AddGalleryItemScreen()),
+          );
+        },
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/FamilyAppFlutter/lib/screens/home_screen.dart
+++ b/FamilyAppFlutter/lib/screens/home_screen.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+
+import 'ai_suggestions_screen.dart';
+import 'calendar_feed_screen.dart';
+import 'calendar_screen.dart';
+import 'call_setup_screen.dart';
+import 'chat_list_screen.dart';
+import 'cloud_call_screen.dart';
+import 'events_screen.dart';
+import 'friends_screen.dart';
+import 'gallery_screen.dart';
+import 'members_screen.dart';
+import 'schedule_screen.dart';
+import 'scoreboard_screen.dart';
+import 'tasks_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  static final List<_Feature> _features = [
+    _Feature(
+      title: 'Members',
+      description: 'Manage family members and view details',
+      icon: Icons.group,
+      builder: (_) => const MembersScreen(),
+    ),
+    _Feature(
+      title: 'Tasks',
+      description: 'Assign chores and track status',
+      icon: Icons.checklist,
+      builder: (_) => const TasksScreen(),
+    ),
+    _Feature(
+      title: 'Events',
+      description: 'Plan family events and gatherings',
+      icon: Icons.event,
+      builder: (_) => const EventsScreen(),
+    ),
+    _Feature(
+      title: 'Calendar',
+      description: 'Overview of upcoming events and tasks',
+      icon: Icons.calendar_today,
+      builder: (_) => const CalendarScreen(),
+    ),
+    _Feature(
+      title: 'Schedule',
+      description: 'Personal schedule and agenda',
+      icon: Icons.schedule,
+      builder: (_) => const ScheduleScreen(),
+    ),
+    _Feature(
+      title: 'Scoreboard',
+      description: 'Gamify tasks with points',
+      icon: Icons.leaderboard,
+      builder: (_) => const ScoreboardScreen(),
+    ),
+    _Feature(
+      title: 'Gallery',
+      description: 'Family photos and memories',
+      icon: Icons.photo_library,
+      builder: (_) => const GalleryScreen(),
+    ),
+    _Feature(
+      title: 'Friends',
+      description: 'Keep track of friends of the family',
+      icon: Icons.people_alt,
+      builder: (_) => const FriendsScreen(),
+    ),
+    _Feature(
+      title: 'Chats',
+      description: 'Group and private conversations',
+      icon: Icons.chat_bubble_outline,
+      builder: (_) => const ChatListScreen(),
+    ),
+    _Feature(
+      title: 'AI suggestions',
+      description: 'Get ideas from the assistant',
+      icon: Icons.auto_awesome,
+      builder: (_) => const AiSuggestionsScreen(),
+    ),
+    _Feature(
+      title: 'Calendar feed',
+      description: 'Latest updates from the calendar',
+      icon: Icons.rss_feed,
+      builder: (_) => const CalendarFeedScreen(),
+    ),
+    _Feature(
+      title: 'Start a call',
+      description: 'Create an audio or video call',
+      icon: Icons.call,
+      builder: (_) => const CallSetupScreen(),
+    ),
+    _Feature(
+      title: 'Cloud call',
+      description: 'Join the cloud call lobby',
+      icon: Icons.cloud,
+      builder: (_) => const CloudCallScreen(),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Family App Hub')),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            const DrawerHeader(
+              decoration: BoxDecoration(color: Colors.indigo),
+              child: Align(
+                alignment: Alignment.bottomLeft,
+                child: Text(
+                  'Family App',
+                  style: TextStyle(color: Colors.white, fontSize: 24),
+                ),
+              ),
+            ),
+            for (final feature in _features)
+              ListTile(
+                leading: Icon(feature.icon),
+                title: Text(feature.title),
+                subtitle: Text(feature.description),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: feature.builder),
+                  );
+                },
+              ),
+          ],
+        ),
+      ),
+      body: GridView.builder(
+        padding: const EdgeInsets.all(16),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          crossAxisSpacing: 16,
+          mainAxisSpacing: 16,
+          childAspectRatio: 1.2,
+        ),
+        itemCount: _features.length,
+        itemBuilder: (context, index) {
+          final feature = _features[index];
+          return _FeatureCard(feature: feature);
+        },
+      ),
+    );
+  }
+}
+
+class _FeatureCard extends StatelessWidget {
+  final _Feature feature;
+
+  const _FeatureCard({required this.feature});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: feature.builder),
+        );
+      },
+      borderRadius: BorderRadius.circular(16),
+      child: Card(
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(feature.icon, size: 40, color: Theme.of(context).colorScheme.primary),
+              const SizedBox(height: 16),
+              Text(
+                feature.title,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                feature.description,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).textTheme.bodySmall?.color,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Feature {
+  final String title;
+  final String description;
+  final IconData icon;
+  final WidgetBuilder builder;
+
+  const _Feature({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.builder,
+  });
+}

--- a/FamilyAppFlutter/lib/screens/member_detail_screen.dart
+++ b/FamilyAppFlutter/lib/screens/member_detail_screen.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../models/family_member.dart';
+import '../providers/family_data.dart';
+import 'add_member_screen.dart';
+import 'edit_documents_screen.dart';
+import 'edit_hobbies_screen.dart';
+import 'member_documents_screen.dart';
+import 'member_hobbies_screen.dart';
+
+class MemberDetailScreen extends StatelessWidget {
+  final String memberId;
+  const MemberDetailScreen({super.key, required this.memberId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<FamilyData>(
+      builder: (context, data, _) {
+        final member = data.memberById(memberId);
+        if (member == null) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Member')),
+            body: const Center(child: Text('Member not found.')),
+          );
+        }
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(member.name?.isNotEmpty == true ? member.name! : 'Member'),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.edit),
+                tooltip: 'Edit member',
+                onPressed: () async {
+                  await Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => AddMemberScreen(initialMember: member),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _InfoTile(
+                title: 'Relationship',
+                value: member.relationship,
+                icon: Icons.group,
+              ),
+              _InfoTile(
+                title: 'Phone',
+                value: member.phone,
+                icon: Icons.phone,
+              ),
+              _InfoTile(
+                title: 'Email',
+                value: member.email,
+                icon: Icons.email,
+              ),
+              _InfoTile(
+                title: 'Social networks',
+                value: member.socialMedia,
+                icon: Icons.share,
+              ),
+              _InfoTile(
+                title: 'Avatar URL',
+                value: member.avatarUrl,
+                icon: Icons.image,
+              ),
+              if (member.birthday != null)
+                ListTile(
+                  leading: const Icon(Icons.cake),
+                  title: const Text('Birthday'),
+                  subtitle: Text(DateFormat('dd.MM.yyyy').format(member.birthday!)),
+                ),
+              if (member.hobbies?.isNotEmpty == true)
+                Card(
+                  margin: const EdgeInsets.symmetric(vertical: 12),
+                  child: ListTile(
+                    leading: const Icon(Icons.local_activity),
+                    title: const Text('Hobbies'),
+                    subtitle: Text(member.hobbies!),
+                  ),
+                ),
+              if (member.documents?.isNotEmpty == true)
+                Card(
+                  margin: const EdgeInsets.symmetric(vertical: 12),
+                  child: ListTile(
+                    leading: const Icon(Icons.description),
+                    title: const Text('Important documents'),
+                    subtitle: Text(member.documents!),
+                  ),
+                ),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  FilledButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => MemberDocumentsScreen(member: member),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.folder_open),
+                    label: const Text('View documents'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => EditDocumentsScreen(member: member),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.edit_document),
+                    label: const Text('Edit documents'),
+                  ),
+                  FilledButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => MemberHobbiesScreen(member: member),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.sports_esports),
+                    label: const Text('View hobbies'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => EditHobbiesScreen(member: member),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.brush),
+                    label: const Text('Edit hobbies'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _InfoTile extends StatelessWidget {
+  final String title;
+  final String? value;
+  final IconData icon;
+
+  const _InfoTile({
+    required this.title,
+    required this.value,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (value == null || value!.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      subtitle: Text(value!),
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/screens/member_documents_screen.dart
+++ b/FamilyAppFlutter/lib/screens/member_documents_screen.dart
@@ -1,15 +1,73 @@
 import 'package:flutter/material.dart';
 
-/// Shows documents for a specific family member.  This simplified
-/// version only displays a placeholder message.
+import '../models/family_member.dart';
+
+/// Shows documents for a specific family member.
 class MemberDocumentsScreen extends StatelessWidget {
-  const MemberDocumentsScreen({super.key});
+  final FamilyMember member;
+  const MemberDocumentsScreen({super.key, required this.member});
 
   @override
   Widget build(BuildContext context) {
+    final docs = member.documentsList ?? const <Map<String, String>>[];
+    final hasSummary = member.documents?.isNotEmpty == true;
     return Scaffold(
-      appBar: AppBar(title: const Text('Member Documents')),
-      body: const Center(child: Text('No documents available.')),
+      appBar: AppBar(
+        title: Text('${member.name ?? 'Member'} documents'),
+      ),
+      body: (docs.isEmpty && !hasSummary)
+          ? const Center(child: Text('No documents available.'))
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                if (hasSummary)
+                  Card(
+                    margin: const EdgeInsets.only(bottom: 16),
+                    child: ListTile(
+                      leading: const Icon(Icons.description),
+                      title: const Text('Summary'),
+                      subtitle: Text(member.documents!),
+                    ),
+                  ),
+                for (final doc in docs) _DocumentCard(document: doc),
+              ],
+            ),
+    );
+  }
+}
+
+class _DocumentCard extends StatelessWidget {
+  final Map<String, String> document;
+  const _DocumentCard({required this.document});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final title = document['title'] ?? document['name'] ?? 'Document';
+    final cleaned = Map<String, String>.from(document);
+    cleaned.remove('title');
+    cleaned.remove('name');
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            if (cleaned.isEmpty)
+              const Text('No additional information')
+            else
+              ...cleaned.entries
+                  .where((entry) => entry.value.trim().isNotEmpty)
+                  .map((entry) => Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Text('${entry.key}: ${entry.value}'),
+                      )),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/member_hobbies_screen.dart
+++ b/FamilyAppFlutter/lib/screens/member_hobbies_screen.dart
@@ -1,15 +1,28 @@
 import 'package:flutter/material.dart';
 
-/// Shows hobbies for a specific family member.  Currently this
-/// simplified screen displays a placeholder message.
+import '../models/family_member.dart';
+
+/// Shows hobbies for a specific family member.
 class MemberHobbiesScreen extends StatelessWidget {
-  const MemberHobbiesScreen({super.key});
+  final FamilyMember member;
+  const MemberHobbiesScreen({super.key, required this.member});
 
   @override
   Widget build(BuildContext context) {
+    final hobbies = member.hobbies;
     return Scaffold(
-      appBar: AppBar(title: const Text('Member Hobbies')),
-      body: const Center(child: Text('No hobbies found.')),
+      appBar: AppBar(
+        title: Text('${member.name ?? 'Member'} hobbies'),
+      ),
+      body: hobbies == null || hobbies.isEmpty
+          ? const Center(child: Text('No hobbies found.'))
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                hobbies,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+            ),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/members_screen.dart
+++ b/FamilyAppFlutter/lib/screens/members_screen.dart
@@ -4,10 +4,11 @@ import 'package:provider/provider.dart';
 import '../models/family_member.dart';
 import '../providers/family_data.dart';
 import 'add_member_screen.dart';
+import 'member_detail_screen.dart';
 
-/// Displays a list of family members.  Each list item shows the
-/// member's name, optional relationship, and a delete button.  A
-/// floating action button allows users to add new members.
+/// Displays a list of family members with quick access to details,
+/// editing and deletion.  Each list item shows the member's initials,
+/// relationship and key contact info.
 class MembersScreen extends StatelessWidget {
   const MembersScreen({super.key});
 
@@ -17,32 +18,75 @@ class MembersScreen extends StatelessWidget {
       builder: (context, data, _) {
         final List<FamilyMember> members = data.members;
         return Scaffold(
-          appBar: AppBar(title: const Text('Members')),
+          appBar: AppBar(title: const Text('Family members')),
           body: members.isEmpty
               ? const Center(child: Text('No members added yet.'))
-              : ListView.builder(
-                  itemCount: members.length,
+              : ListView.separated(
+                  padding: const EdgeInsets.all(12),
                   itemBuilder: (context, index) {
                     final member = members[index];
-                    return ListTile(
-                      leading: CircleAvatar(
-                        child: Text(
-                          (member.name ?? '').isNotEmpty
-                              ? member.name![0].toUpperCase()
-                              : '?',
+                    return Card(
+                      child: ListTile(
+                        leading: CircleAvatar(
+                          child: Text(_initials(member)),
                         ),
-                      ),
-                      title: Text(member.name ?? 'No name'),
-                      subtitle: Text(member.relationship ?? ''),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.delete),
-                        onPressed: () {
-                          data.members.removeAt(index);
-                          
+                        title: Text(member.name ?? 'No name'),
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            if (member.relationship?.isNotEmpty == true)
+                              Text(member.relationship!),
+                            if (member.phone?.isNotEmpty == true)
+                              Text(member.phone!),
+                            if (member.email?.isNotEmpty == true)
+                              Text(member.email!),
+                          ],
+                        ),
+                        isThreeLine: true,
+                        onTap: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => MemberDetailScreen(memberId: member.id),
+                            ),
+                          );
                         },
+                        trailing: PopupMenuButton<String>(
+                          onSelected: (value) {
+                            switch (value) {
+                              case 'edit':
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder: (_) => AddMemberScreen(initialMember: member),
+                                  ),
+                                );
+                                break;
+                              case 'delete':
+                                _confirmDeletion(context, member);
+                                break;
+                            }
+                          },
+                          itemBuilder: (context) => const [
+                            PopupMenuItem(
+                              value: 'edit',
+                              child: ListTile(
+                                leading: Icon(Icons.edit),
+                                title: Text('Edit'),
+                              ),
+                            ),
+                            PopupMenuItem(
+                              value: 'delete',
+                              child: ListTile(
+                                leading: Icon(Icons.delete),
+                                title: Text('Delete'),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     );
                   },
+                  separatorBuilder: (_, __) => const SizedBox(height: 8),
+                  itemCount: members.length,
                 ),
           floatingActionButton: FloatingActionButton(
             onPressed: () {
@@ -52,6 +96,46 @@ class MembersScreen extends StatelessWidget {
             },
             child: const Icon(Icons.add),
           ),
+        );
+      },
+    );
+  }
+
+  String _initials(FamilyMember member) {
+    final name = member.name ?? '';
+    if (name.isNotEmpty) {
+      final parts = name.trim().split(RegExp(r'\s+'));
+      if (parts.length > 1) {
+        return (parts.first[0] + parts.last[0]).toUpperCase();
+      }
+      return name[0].toUpperCase();
+    }
+    return '?';
+  }
+
+  void _confirmDeletion(BuildContext context, FamilyMember member) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) {
+        return AlertDialog(
+          title: const Text('Delete member'),
+          content: Text('Remove ${member.name ?? 'this member'} from the family?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                context.read<FamilyData>().removeMember(member);
+                Navigator.of(ctx).pop();
+              },
+              style: FilledButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.errorContainer,
+              ),
+              child: const Text('Delete'),
+            ),
+          ],
         );
       },
     );

--- a/FamilyAppFlutter/lib/screens/schedule_screen.dart
+++ b/FamilyAppFlutter/lib/screens/schedule_screen.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../providers/schedule_data.dart';
 import '../models/schedule_item.dart';
+import '../providers/family_data.dart';
+import '../providers/schedule_data.dart';
+import 'add_schedule_item_screen.dart';
 
-/// Displays a list of scheduled items.  Each item shows its title and
-/// date/time.  New items can be added via some other screen.
+/// Displays a list of scheduled items.  Each item shows its title,
+/// time range and linked member.  New items can be added via the
+/// floating action button.
 class ScheduleScreen extends StatelessWidget {
   const ScheduleScreen({super.key});
 
@@ -13,23 +17,82 @@ class ScheduleScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Schedule')),
-      body: Consumer<ScheduleData>(
-        builder: (context, data, _) {
-          if (data.items.isEmpty) {
+      body: Consumer2<ScheduleData, FamilyData>(
+        builder: (context, scheduleData, familyData, _) {
+          if (scheduleData.items.isEmpty) {
             return const Center(child: Text('No scheduled items.'));
           }
-          return ListView.builder(
-            itemCount: data.items.length,
+          final items = scheduleData.items.toList()
+            ..sort((a, b) => a.dateTime.compareTo(b.dateTime));
+          return ListView.separated(
+            padding: const EdgeInsets.all(12),
             itemBuilder: (context, index) {
-              final ScheduleItem item = data.items[index];
-              return ListTile(
-                leading: const Icon(Icons.calendar_today),
-                title: Text(item.title),
-                subtitle: Text(item.dateTime.toString()),
+              final ScheduleItem item = items[index];
+              final memberName = familyData.memberById(item.memberId ?? '')?.name;
+              return Card(
+                child: ListTile(
+                  leading: const Icon(Icons.calendar_today),
+                  title: Text(item.title),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(_formatRange(item)),
+                      if (memberName != null && memberName.isNotEmpty)
+                        Text('Member: $memberName'),
+                      if (item.location?.isNotEmpty == true)
+                        Text('Location: ${item.location}'),
+                      if (item.notes?.isNotEmpty == true)
+                        Text('Notes: ${item.notes}'),
+                    ],
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: () => _confirmDelete(context, item.id),
+                  ),
+                ),
               );
             },
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            itemCount: items.length,
           );
         },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const AddScheduleItemScreen()),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  String _formatRange(ScheduleItem item) {
+    final start = DateFormat('dd.MM.yyyy HH:mm').format(item.dateTime);
+    final end = DateFormat('dd.MM.yyyy HH:mm').format(item.endDateTime);
+    return '$start – $end';
+  }
+
+  void _confirmDelete(BuildContext context, String id) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete entry'),
+        content: const Text('Remove this item from the schedule?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              context.read<ScheduleData>().removeItem(id);
+              Navigator.of(ctx).pop();
+            },
+            child: const Text('Delete'),
+          ),
+        ],
       ),
     );
   }

--- a/FamilyAppFlutter/lib/screens/tasks_screen.dart
+++ b/FamilyAppFlutter/lib/screens/tasks_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../providers/family_data.dart';
 import '../models/task.dart';
+import '../providers/family_data.dart';
 import 'add_task_screen.dart';
 
 /// Displays a list of tasks and allows adding new tasks.  Each task
-/// shows its title, status and assigned member if applicable.
+/// shows its title, status, due date, assigned member and points.
 class TasksScreen extends StatelessWidget {
   const TasksScreen({super.key});
 
@@ -20,14 +21,105 @@ class TasksScreen extends StatelessWidget {
           if (tasks.isEmpty) {
             return const Center(child: Text('No tasks added yet.'));
           }
-          return ListView.builder(
+          return ListView.separated(
+            padding: const EdgeInsets.all(12),
             itemCount: tasks.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
             itemBuilder: (context, index) {
-              final Task task = tasks[index];
-              return ListTile(
-                leading: const Icon(Icons.check_box_outline_blank),
-                title: Text(task.title),
-                subtitle: Text(task.status.name),
+              final task = tasks[index];
+              final assigneeName = task.assigneeId == null
+                  ? null
+                  : data.memberById(task.assigneeId!)?.name;
+              return Card(
+                child: ListTile(
+                  leading: Icon(
+                    _statusIcon(task.status),
+                    color: _statusColor(context, task.status),
+                  ),
+                  title: Text(task.title),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Chip(
+                        label: Text(task.status.name),
+                        backgroundColor:
+                            _statusColor(context, task.status).withValues(alpha: 0.12),
+                      ),
+                      if (task.description?.isNotEmpty == true)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(task.description!),
+                        ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          'Due: ${_formatDueDate(task.dueDate)}',
+                        ),
+                      ),
+                      Text(
+                        'Assignee: ${assigneeName?.isNotEmpty == true ? assigneeName : 'Unassigned'}',
+                      ),
+                      if (task.points != null)
+                        Text('Points: ${task.points}'),
+                    ],
+                  ),
+                  isThreeLine: true,
+                  trailing: PopupMenuButton<String>(
+                    onSelected: (value) {
+                      switch (value) {
+                        case 'todo':
+                          context
+                              .read<FamilyData>()
+                              .updateTaskStatus(task.id, TaskStatus.todo);
+                          break;
+                        case 'inProgress':
+                          context
+                              .read<FamilyData>()
+                              .updateTaskStatus(task.id, TaskStatus.inProgress);
+                          break;
+                        case 'done':
+                          context
+                              .read<FamilyData>()
+                              .updateTaskStatus(task.id, TaskStatus.done);
+                          break;
+                        case 'delete':
+                          _confirmDelete(context, task);
+                          break;
+                      }
+                    },
+                    itemBuilder: (context) => const [
+                      PopupMenuItem(
+                        value: 'todo',
+                        child: ListTile(
+                          leading: Icon(Icons.radio_button_unchecked),
+                          title: Text('Mark as TODO'),
+                        ),
+                      ),
+                      PopupMenuItem(
+                        value: 'inProgress',
+                        child: ListTile(
+                          leading: Icon(Icons.timelapse),
+                          title: Text('Mark in progress'),
+                        ),
+                      ),
+                      PopupMenuItem(
+                        value: 'done',
+                        child: ListTile(
+                          leading: Icon(Icons.check_circle),
+                          title: Text('Mark as done'),
+                        ),
+                      ),
+                      PopupMenuDivider(),
+                      PopupMenuItem(
+                        value: 'delete',
+                        child: ListTile(
+                          leading: Icon(Icons.delete),
+                          title: Text('Delete task'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               );
             },
           );
@@ -40,6 +132,57 @@ class TasksScreen extends StatelessWidget {
           );
         },
         child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  String _formatDueDate(DateTime? date) {
+    if (date == null) return 'No due date';
+    return DateFormat('dd.MM.yyyy HH:mm').format(date);
+  }
+
+  IconData _statusIcon(TaskStatus status) {
+    switch (status) {
+      case TaskStatus.todo:
+        return Icons.radio_button_unchecked;
+      case TaskStatus.inProgress:
+        return Icons.timelapse;
+      case TaskStatus.done:
+        return Icons.check_circle;
+    }
+  }
+
+  Color _statusColor(BuildContext context, TaskStatus status) {
+    final colors = Theme.of(context).colorScheme;
+    switch (status) {
+      case TaskStatus.todo:
+        return colors.primary;
+      case TaskStatus.inProgress:
+        return colors.tertiary;
+      case TaskStatus.done:
+        return colors.secondary;
+    }
+  }
+
+  void _confirmDelete(BuildContext context, Task task) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete task'),
+        content: Text('Delete "${task.title}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              context.read<FamilyData>().removeTask(task.id);
+              Navigator.of(ctx).pop();
+            },
+            child: const Text('Delete'),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- restore a home hub that links to all major modules and wire providers for navigation
- expand member, task, event, schedule and supporting forms to capture full data and display details
- bring back gallery, friends, chat and call experiences with ability to add/manage content

## Testing
- Not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d14c5e4efc832b99c5c836ef52fee4