### PR TITLE
Add Dart analysis workflow

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,28 @@
+name: Dart Analysis
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    name: Flutter Analyze
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: FamilyAppFlutter
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run analyzer
+        run: flutter analyze


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs Flutter dependencies and runs `flutter analyze` on pushes to main

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d17d1e2424832ba542573f7ac34fc5