### PR TITLE
Add localization infrastructure with language menu selection

### DIFF
--- a/FamilyAppFlutter/lib/l10n/app_localizations.dart
+++ b/FamilyAppFlutter/lib/l10n/app_localizations.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static const supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ru'),
+  ];
+
+  static const localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    _AppLocalizationsDelegate(),
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+  ];
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const _localizedValues = <String, Map<String, String>>{
+    'en': {
+      'appTitle': 'Family App',
+      'homeHubTitle': 'Family App Hub',
+      'drawerTitle': 'Family App',
+      'languageMenuTitle': 'Language',
+      'languageMenuSubtitle': 'Choose interface language',
+      'languageEnglish': 'English',
+      'languageRussian': 'Russian',
+      'feature.members.title': 'Members',
+      'feature.members.description':
+          'Manage family members and view details',
+      'feature.tasks.title': 'Tasks',
+      'feature.tasks.description': 'Assign chores and track status',
+      'feature.events.title': 'Events',
+      'feature.events.description': 'Plan family events and gatherings',
+      'feature.calendar.title': 'Calendar',
+      'feature.calendar.description':
+          'Overview of upcoming events and tasks',
+      'feature.schedule.title': 'Schedule',
+      'feature.schedule.description': 'Personal schedule and agenda',
+      'feature.scoreboard.title': 'Scoreboard',
+      'feature.scoreboard.description': 'Gamify tasks with points',
+      'feature.gallery.title': 'Gallery',
+      'feature.gallery.description': 'Family photos and memories',
+      'feature.friends.title': 'Friends',
+      'feature.friends.description':
+          'Keep track of friends of the family',
+      'feature.chats.title': 'Chats',
+      'feature.chats.description': 'Group and private conversations',
+      'feature.ai.title': 'AI suggestions',
+      'feature.ai.description': 'Get ideas from the assistant',
+      'feature.calendarFeed.title': 'Calendar feed',
+      'feature.calendarFeed.description': 'Latest updates from the calendar',
+      'feature.callSetup.title': 'Start a call',
+      'feature.callSetup.description': 'Create an audio or video call',
+      'feature.cloudCall.title': 'Cloud call',
+      'feature.cloudCall.description': 'Join the cloud call lobby',
+    },
+    'ru': {
+      'appTitle': 'Family App',
+      'homeHubTitle': 'Центр управления Family App',
+      'drawerTitle': 'Family App',
+      'languageMenuTitle': 'Язык',
+      'languageMenuSubtitle': 'Выберите язык интерфейса',
+      'languageEnglish': 'Английский',
+      'languageRussian': 'Русский',
+      'feature.members.title': 'Участники',
+      'feature.members.description':
+          'Управляйте членами семьи и просматривайте данные',
+      'feature.tasks.title': 'Задачи',
+      'feature.tasks.description': 'Назначайте поручения и отслеживайте статус',
+      'feature.events.title': 'События',
+      'feature.events.description':
+          'Планируйте семейные события и встречи',
+      'feature.calendar.title': 'Календарь',
+      'feature.calendar.description':
+          'Обзор предстоящих событий и задач',
+      'feature.schedule.title': 'Расписание',
+      'feature.schedule.description': 'Личное расписание и дела',
+      'feature.scoreboard.title': 'Таблица лидеров',
+      'feature.scoreboard.description': 'Геймификация задач с баллами',
+      'feature.gallery.title': 'Галерея',
+      'feature.gallery.description': 'Семейные фото и воспоминания',
+      'feature.friends.title': 'Друзья',
+      'feature.friends.description':
+          'Следите за друзьями семьи',
+      'feature.chats.title': 'Чаты',
+      'feature.chats.description': 'Групповые и личные беседы',
+      'feature.ai.title': 'AI-подсказки',
+      'feature.ai.description': 'Получайте идеи от помощника',
+      'feature.calendarFeed.title': 'Лента календаря',
+      'feature.calendarFeed.description': 'Последние обновления из календаря',
+      'feature.callSetup.title': 'Начать звонок',
+      'feature.callSetup.description': 'Создайте аудио- или видеозвонок',
+      'feature.cloudCall.title': 'Облачный звонок',
+      'feature.cloudCall.description': 'Подключайтесь к общему лобби звонка',
+    },
+  };
+
+  String t(String key, {Map<String, String>? params}) {
+    final languageCode = locale.languageCode;
+    final template = _localizedValues[languageCode]?[key] ??
+        _localizedValues['en']?[key] ??
+        key;
+    if (params == null || params.isEmpty) {
+      return template;
+    }
+    var result = template;
+    params.forEach((placeholder, value) {
+      result = result.replaceAll('{$placeholder}', value);
+    });
+    return result;
+  }
+
+  String languageName(String code) {
+    switch (code) {
+      case 'ru':
+        return t('languageRussian');
+      case 'en':
+      default:
+        return t('languageEnglish');
+    }
+  }
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return AppLocalizations.supportedLocales
+        .any((supportedLocale) => supportedLocale.languageCode == locale.languageCode);
+  }
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) => false;
+}
+
+extension AppLocalizationExtension on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this);
+}

--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
+import 'l10n/app_localizations.dart';
 import 'providers/chat_provider.dart';
 import 'providers/family_data.dart';
 import 'providers/friends_data.dart';
 import 'providers/gallery_data.dart';
+import 'providers/language_provider.dart';
 import 'providers/schedule_data.dart';
 import 'screens/home_screen.dart';
 
@@ -14,33 +16,54 @@ import 'screens/home_screen.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
+  final settingsBox = await Hive.openBox('settings');
   final chatProvider = ChatProvider();
   await chatProvider.init();
-  runApp(MyApp(chatProvider: chatProvider));
+  final languageProvider = LanguageProvider(box: settingsBox);
+  runApp(
+    MyApp(
+      chatProvider: chatProvider,
+      languageProvider: languageProvider,
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
   final ChatProvider chatProvider;
-  const MyApp({super.key, required this.chatProvider});
+  final LanguageProvider languageProvider;
+
+  const MyApp({
+    super.key,
+    required this.chatProvider,
+    required this.languageProvider,
+  });
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<ChatProvider>.value(value: chatProvider),
+        ChangeNotifierProvider<LanguageProvider>.value(value: languageProvider),
         ChangeNotifierProvider(create: (_) => FamilyData()),
         ChangeNotifierProvider(create: (_) => FriendsData()),
         ChangeNotifierProvider(create: (_) => GalleryData()),
         ChangeNotifierProvider(create: (_) => ScheduleData()),
       ],
-      child: MaterialApp(
-        title: 'Family App',
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
-          useMaterial3: true,
-        ),
-        home: const HomeScreen(),
+      child: Consumer<LanguageProvider>(
+        builder: (context, language, _) {
+          return MaterialApp(
+            debugShowCheckedModeBanner: false,
+            onGenerateTitle: (context) => context.l10n.t('appTitle'),
+            locale: language.locale,
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+              useMaterial3: true,
+            ),
+            home: const HomeScreen(),
+          );
+        },
       ),
     );
   }

--- a/FamilyAppFlutter/lib/providers/language_provider.dart
+++ b/FamilyAppFlutter/lib/providers/language_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+
+import '../l10n/app_localizations.dart';
+
+class LanguageProvider extends ChangeNotifier {
+  LanguageProvider({Box<dynamic>? box}) : _box = box {
+    final savedCode = _box?.get(_languageCode) as String?;
+    if (savedCode != null && _isSupported(savedCode)) {
+      _locale = Locale(savedCode);
+    }
+  }
+
+  static const _languageCode = 'language_code';
+  final Box<dynamic>? _box;
+  Locale _locale = const Locale('en');
+
+  Locale get locale => _locale;
+
+  void setLocale(Locale locale) {
+    if (_locale == locale || !_isSupported(locale.languageCode)) {
+      return;
+    }
+    _locale = locale;
+    _box?.put(_languageCode, locale.languageCode);
+    notifyListeners();
+  }
+
+  bool _isSupported(String code) {
+    return AppLocalizations.supportedLocales
+        .any((locale) => locale.languageCode == code);
+  }
+}

--- a/FamilyAppFlutter/lib/screens/home_screen.dart
+++ b/FamilyAppFlutter/lib/screens/home_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
+import '../providers/language_provider.dart';
 import 'ai_suggestions_screen.dart';
 import 'calendar_feed_screen.dart';
 import 'calendar_screen.dart';
@@ -17,106 +20,54 @@ import 'tasks_screen.dart';
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
-  static final List<_Feature> _features = [
-    _Feature(
-      title: 'Members',
-      description: 'Manage family members and view details',
-      icon: Icons.group,
-      builder: (_) => const MembersScreen(),
-    ),
-    _Feature(
-      title: 'Tasks',
-      description: 'Assign chores and track status',
-      icon: Icons.checklist,
-      builder: (_) => const TasksScreen(),
-    ),
-    _Feature(
-      title: 'Events',
-      description: 'Plan family events and gatherings',
-      icon: Icons.event,
-      builder: (_) => const EventsScreen(),
-    ),
-    _Feature(
-      title: 'Calendar',
-      description: 'Overview of upcoming events and tasks',
-      icon: Icons.calendar_today,
-      builder: (_) => const CalendarScreen(),
-    ),
-    _Feature(
-      title: 'Schedule',
-      description: 'Personal schedule and agenda',
-      icon: Icons.schedule,
-      builder: (_) => const ScheduleScreen(),
-    ),
-    _Feature(
-      title: 'Scoreboard',
-      description: 'Gamify tasks with points',
-      icon: Icons.leaderboard,
-      builder: (_) => const ScoreboardScreen(),
-    ),
-    _Feature(
-      title: 'Gallery',
-      description: 'Family photos and memories',
-      icon: Icons.photo_library,
-      builder: (_) => const GalleryScreen(),
-    ),
-    _Feature(
-      title: 'Friends',
-      description: 'Keep track of friends of the family',
-      icon: Icons.people_alt,
-      builder: (_) => const FriendsScreen(),
-    ),
-    _Feature(
-      title: 'Chats',
-      description: 'Group and private conversations',
-      icon: Icons.chat_bubble_outline,
-      builder: (_) => const ChatListScreen(),
-    ),
-    _Feature(
-      title: 'AI suggestions',
-      description: 'Get ideas from the assistant',
-      icon: Icons.auto_awesome,
-      builder: (_) => const AiSuggestionsScreen(),
-    ),
-    _Feature(
-      title: 'Calendar feed',
-      description: 'Latest updates from the calendar',
-      icon: Icons.rss_feed,
-      builder: (_) => const CalendarFeedScreen(),
-    ),
-    _Feature(
-      title: 'Start a call',
-      description: 'Create an audio or video call',
-      icon: Icons.call,
-      builder: (_) => const CallSetupScreen(),
-    ),
-    _Feature(
-      title: 'Cloud call',
-      description: 'Join the cloud call lobby',
-      icon: Icons.cloud,
-      builder: (_) => const CloudCallScreen(),
-    ),
-  ];
-
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final languageProvider = context.watch<LanguageProvider>();
+    final features = _buildFeatures(context);
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Family App Hub')),
+      appBar: AppBar(title: Text(l10n.t('homeHubTitle'))),
       drawer: Drawer(
         child: ListView(
           padding: EdgeInsets.zero,
           children: [
-            const DrawerHeader(
-              decoration: BoxDecoration(color: Colors.indigo),
+            DrawerHeader(
+              decoration: const BoxDecoration(color: Colors.indigo),
               child: Align(
                 alignment: Alignment.bottomLeft,
                 child: Text(
-                  'Family App',
-                  style: TextStyle(color: Colors.white, fontSize: 24),
+                  l10n.t('drawerTitle'),
+                  style: const TextStyle(color: Colors.white, fontSize: 24),
                 ),
               ),
             ),
-            for (final feature in _features)
+            ListTile(
+              leading: const Icon(Icons.language),
+              title: Text(l10n.t('languageMenuTitle')),
+              subtitle: Text(l10n.t('languageMenuSubtitle')),
+              trailing: DropdownButtonHideUnderline(
+                child: DropdownButton<Locale>(
+                  value: languageProvider.locale,
+                  onChanged: (locale) {
+                    if (locale != null) {
+                      context.read<LanguageProvider>().setLocale(locale);
+                    }
+                  },
+                  items: [
+                    for (final locale in AppLocalizations.supportedLocales)
+                      DropdownMenuItem<Locale>(
+                        value: locale,
+                        child: Text(
+                          l10n.languageName(locale.languageCode),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+            const Divider(height: 1),
+            for (final feature in features)
               ListTile(
                 leading: Icon(feature.icon),
                 title: Text(feature.title),
@@ -139,13 +90,97 @@ class HomeScreen extends StatelessWidget {
           mainAxisSpacing: 16,
           childAspectRatio: 1.2,
         ),
-        itemCount: _features.length,
+        itemCount: features.length,
         itemBuilder: (context, index) {
-          final feature = _features[index];
+          final feature = features[index];
           return _FeatureCard(feature: feature);
         },
       ),
     );
+  }
+
+  List<_Feature> _buildFeatures(BuildContext context) {
+    final l10n = context.l10n;
+    return [
+      _Feature(
+        title: l10n.t('feature.members.title'),
+        description: l10n.t('feature.members.description'),
+        icon: Icons.group,
+        builder: (_) => const MembersScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.tasks.title'),
+        description: l10n.t('feature.tasks.description'),
+        icon: Icons.checklist,
+        builder: (_) => const TasksScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.events.title'),
+        description: l10n.t('feature.events.description'),
+        icon: Icons.event,
+        builder: (_) => const EventsScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.calendar.title'),
+        description: l10n.t('feature.calendar.description'),
+        icon: Icons.calendar_today,
+        builder: (_) => const CalendarScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.schedule.title'),
+        description: l10n.t('feature.schedule.description'),
+        icon: Icons.schedule,
+        builder: (_) => const ScheduleScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.scoreboard.title'),
+        description: l10n.t('feature.scoreboard.description'),
+        icon: Icons.leaderboard,
+        builder: (_) => const ScoreboardScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.gallery.title'),
+        description: l10n.t('feature.gallery.description'),
+        icon: Icons.photo_library,
+        builder: (_) => const GalleryScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.friends.title'),
+        description: l10n.t('feature.friends.description'),
+        icon: Icons.people_alt,
+        builder: (_) => const FriendsScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.chats.title'),
+        description: l10n.t('feature.chats.description'),
+        icon: Icons.chat_bubble_outline,
+        builder: (_) => const ChatListScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.ai.title'),
+        description: l10n.t('feature.ai.description'),
+        icon: Icons.auto_awesome,
+        builder: (_) => const AiSuggestionsScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.calendarFeed.title'),
+        description: l10n.t('feature.calendarFeed.description'),
+        icon: Icons.rss_feed,
+        builder: (_) => const CalendarFeedScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.callSetup.title'),
+        description: l10n.t('feature.callSetup.description'),
+        icon: Icons.call,
+        builder: (_) => const CallSetupScreen(),
+      ),
+      _Feature(
+        title: l10n.t('feature.cloudCall.title'),
+        description: l10n.t('feature.cloudCall.description'),
+        icon: Icons.cloud,
+        builder: (_) => const CloudCallScreen(),
+      ),
+    ];
   }
 }
 

--- a/FamilyAppFlutter/lib/screens/member_detail_screen.dart
+++ b/FamilyAppFlutter/lib/screens/member_detail_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../models/family_member.dart';
 import '../providers/family_data.dart';
 import 'add_member_screen.dart';
 import 'edit_documents_screen.dart';

--- a/FamilyAppFlutter/pubspec.yaml
+++ b/FamilyAppFlutter/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   provider: ^6.0.5
   firebase_core: ^3.15.2
   cloud_firestore: ^5.6.12

--- a/FamilyAppFlutter/test/widget_test.dart
+++ b/FamilyAppFlutter/test/widget_test.dart
@@ -1,11 +1,18 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:family_app_flutter/main.dart';
 import 'package:family_app_flutter/providers/chat_provider.dart';
+import 'package:family_app_flutter/providers/language_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('App smoke test', (WidgetTester tester) async {
     // Создаём минимальный экземпляр приложения с пустым ChatProvider.
     final chatProvider = ChatProvider();
-    await tester.pumpWidget(MyApp(chatProvider: chatProvider));
+    final languageProvider = LanguageProvider();
+    await tester.pumpWidget(
+      MyApp(
+        chatProvider: chatProvider,
+        languageProvider: languageProvider,
+      ),
+    );
   });
 }


### PR DESCRIPTION
## Summary
- add application localization resources and a language provider that persists the choice
- connect MaterialApp to the selected locale and expose a language dropdown in the home menu
- update the widget smoke test and clean an analyzer warning

## Testing
- not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d17a9aa2c8832b90a2f18dcfedbc7e