### PR TITLE
Fix analyzer warnings in add screens and services

### DIFF
--- a/FamilyAppFlutter/lib/screens/add_event_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_event_screen.dart
@@ -39,11 +39,13 @@ class _AddEventScreenState extends State<AddEventScreen> {
       firstDate: DateTime(now.year - 1),
       lastDate: DateTime(now.year + 5),
     );
+    if (!mounted) return;
     if (date == null) return;
     final time = await showTimePicker(
       context: context,
       initialTime: TimeOfDay.fromDateTime(initial),
     );
+    if (!mounted) return;
     setState(() {
       _startDate = DateTime(
         date.year,
@@ -68,11 +70,13 @@ class _AddEventScreenState extends State<AddEventScreen> {
       firstDate: start,
       lastDate: DateTime(now.year + 5),
     );
+    if (!mounted) return;
     if (date == null) return;
     final time = await showTimePicker(
       context: context,
       initialTime: TimeOfDay.fromDateTime(initial),
     );
+    if (!mounted) return;
     setState(() {
       _endDate = DateTime(
         date.year,

--- a/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
@@ -48,6 +48,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
       firstDate: DateTime(now.year - 1),
       lastDate: DateTime(now.year + 5),
     );
+    if (!mounted) return;
     if (date == null) return;
     final time = await showTimePicker(
       context: context,
@@ -127,7 +128,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<Duration?>(
-                  value: _duration,
+                  initialValue: _duration,
                   decoration: const InputDecoration(labelText: 'Duration'),
                   items: [
                     const DropdownMenuItem<Duration?>(
@@ -145,7 +146,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String?>(
-                  value: _memberId,
+                  initialValue: _memberId,
                   decoration: const InputDecoration(labelText: 'Assign to member'),
                   items: [
                     const DropdownMenuItem<String?>(

--- a/FamilyAppFlutter/lib/screens/add_task_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_task_screen.dart
@@ -33,11 +33,13 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
       firstDate: DateTime(now.year - 1),
       lastDate: DateTime(now.year + 5),
     );
+    if (!mounted) return;
     if (date == null) return;
     final timeOfDay = await showTimePicker(
       context: context,
       initialTime: TimeOfDay.fromDateTime(_dueDate ?? now),
     );
+    if (!mounted) return;
     setState(() {
       _dueDate = DateTime(
         date.year,
@@ -125,7 +127,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<TaskStatus>(
-                  value: _status,
+                  initialValue: _status,
                   decoration: const InputDecoration(labelText: 'Status'),
                   items: TaskStatus.values
                       .map(
@@ -143,7 +145,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String?>(
-                  value: _assigneeId,
+                  initialValue: _assigneeId,
                   decoration: const InputDecoration(labelText: 'Assign to'),
                   items: [
                     const DropdownMenuItem<String?>(

--- a/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
+++ b/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
@@ -241,12 +241,12 @@ class _EmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
+    return const Center(
       child: Opacity(
         opacity: 0.7,
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          children: const [
+          children: [
             Icon(Icons.lightbulb, size: 48),
             SizedBox(height: 8),
             Text('Пока нет подсказок — введите запрос и нажмите «Сгенерировать».'),

--- a/FamilyAppFlutter/lib/screens/call_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_screen.dart
@@ -11,10 +11,10 @@ class CallScreen extends StatelessWidget {
   final String callType; // 'audio' or 'video'
 
   const CallScreen({
-    Key? key,
+    super.key,
     required this.conversation,
     required this.callType,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/FamilyAppFlutter/lib/services/firestore_service.dart
+++ b/FamilyAppFlutter/lib/services/firestore_service.dart
@@ -11,7 +11,7 @@ import '../security/encrypted_firestore_service.dart';
 /// Service wrapping common Firestore operations for the app.
 class FirestoreService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
-  final EncryptedFirestoreService _enc = EncryptedFirestoreService();
+  final EncryptedFirestoreService _enc = const EncryptedFirestoreService();
 
   /// --------- FAMILY MEMBERS (encrypted upsert in DataSyncService) ----------
   Future<List<FamilyMember>> fetchFamilyMembers(String familyId) async {


### PR DESCRIPTION
## Summary
- guard async picker flows against unmounted contexts in add screens
- migrate dropdown form fields to the new `initialValue` API
- adopt const/super parameter cleanups to satisfy remaining analyzer lints

## Testing
- not run (flutter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d18401b198832bbd07cdc094480017