### PR TITLE
Merge main into codex_check resolving localization conflicts

### DIFF
--- a/FamilyAppFlutter/lib/config/app_config.dart
+++ b/FamilyAppFlutter/lib/config/app_config.dart
@@ -1,0 +1,6 @@
+/// Global configuration for the application.
+class AppConfig {
+  /// Identifier of the family document used to scope Firestore data.
+  static const String familyId = 'default_family';
+}
+

--- a/FamilyAppFlutter/lib/l10n/app_localizations.dart
+++ b/FamilyAppFlutter/lib/l10n/app_localizations.dart
@@ -1,131 +1,1869 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
+/// Provides localized strings for the application without relying on the
+/// Flutter localization toolchain.  The implementation is intentionally
+/// lightweight so new keys can quickly be added to the map below.
 class AppLocalizations {
   AppLocalizations(this.locale);
 
-  final Locale locale;
+  /// Delegate used by [MaterialApp] to load the localization class.
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
-  static const supportedLocales = <Locale>[
+  /// List of locales supported by the application.
+  static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
     Locale('ru'),
+    Locale('de'),
+    Locale('fr'),
+    Locale('es'),
+    Locale('zh'),
   ];
 
-  static const localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    _AppLocalizationsDelegate(),
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+    delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalWidgetsLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
   ];
 
+  final Locale locale;
+
+  /// Returns the canonical locale string (e.g. `en`, `ru`).
+  String get localeName => Intl.canonicalizedLocale(locale.toString());
+
+  /// Loads the localization data for the provided [locale].
+  static Future<AppLocalizations> load(Locale locale) async {
+    final String localeName = Intl.canonicalizedLocale(locale.toString());
+    await initializeDateFormatting(localeName);
+    Intl.defaultLocale = localeName;
+    return AppLocalizations(locale);
+  }
+
+  /// Helper to access the localization instance through the [context].
   static AppLocalizations of(BuildContext context) {
     return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
 
-  static const _localizedValues = <String, Map<String, String>>{
-    'en': {
-      'appTitle': 'Family App',
-      'homeHubTitle': 'Family App Hub',
-      'drawerTitle': 'Family App',
-      'languageMenuTitle': 'Language',
-      'languageMenuSubtitle': 'Choose interface language',
-      'languageEnglish': 'English',
-      'languageRussian': 'Russian',
-      'feature.members.title': 'Members',
-      'feature.members.description':
-          'Manage family members and view details',
-      'feature.tasks.title': 'Tasks',
-      'feature.tasks.description': 'Assign chores and track status',
-      'feature.events.title': 'Events',
-      'feature.events.description': 'Plan family events and gatherings',
-      'feature.calendar.title': 'Calendar',
-      'feature.calendar.description':
-          'Overview of upcoming events and tasks',
-      'feature.schedule.title': 'Schedule',
-      'feature.schedule.description': 'Personal schedule and agenda',
-      'feature.scoreboard.title': 'Scoreboard',
-      'feature.scoreboard.description': 'Gamify tasks with points',
-      'feature.gallery.title': 'Gallery',
-      'feature.gallery.description': 'Family photos and memories',
-      'feature.friends.title': 'Friends',
-      'feature.friends.description':
-          'Keep track of friends of the family',
-      'feature.chats.title': 'Chats',
-      'feature.chats.description': 'Group and private conversations',
-      'feature.ai.title': 'AI suggestions',
-      'feature.ai.description': 'Get ideas from the assistant',
-      'feature.calendarFeed.title': 'Calendar feed',
-      'feature.calendarFeed.description': 'Latest updates from the calendar',
-      'feature.callSetup.title': 'Start a call',
-      'feature.callSetup.description': 'Create an audio or video call',
-      'feature.cloudCall.title': 'Cloud call',
-      'feature.cloudCall.description': 'Join the cloud call lobby',
+  /// Base translation table.  Each entry contains the translations for the
+  /// supported locales.  Additional keys can be appended as needed.
+  static const Map<String, Map<String, String>> _localizedValues = {
+    'appTitle': {
+      'en': 'Family App',
+      'ru': 'Семейное приложение',
+      'de': 'Familien-App',
+      'fr': 'Application familiale',
+      'es': 'Aplicación familiar',
+      'zh': '家庭应用',
     },
-    'ru': {
-      'appTitle': 'Family App',
-      'homeHubTitle': 'Центр управления Family App',
-      'drawerTitle': 'Family App',
-      'languageMenuTitle': 'Язык',
-      'languageMenuSubtitle': 'Выберите язык интерфейса',
-      'languageEnglish': 'Английский',
-      'languageRussian': 'Русский',
-      'feature.members.title': 'Участники',
-      'feature.members.description':
-          'Управляйте членами семьи и просматривайте данные',
-      'feature.tasks.title': 'Задачи',
-      'feature.tasks.description': 'Назначайте поручения и отслеживайте статус',
-      'feature.events.title': 'События',
-      'feature.events.description':
-          'Планируйте семейные события и встречи',
-      'feature.calendar.title': 'Календарь',
-      'feature.calendar.description':
-          'Обзор предстоящих событий и задач',
-      'feature.schedule.title': 'Расписание',
-      'feature.schedule.description': 'Личное расписание и дела',
-      'feature.scoreboard.title': 'Таблица лидеров',
-      'feature.scoreboard.description': 'Геймификация задач с баллами',
-      'feature.gallery.title': 'Галерея',
-      'feature.gallery.description': 'Семейные фото и воспоминания',
-      'feature.friends.title': 'Друзья',
-      'feature.friends.description':
-          'Следите за друзьями семьи',
-      'feature.chats.title': 'Чаты',
-      'feature.chats.description': 'Групповые и личные беседы',
-      'feature.ai.title': 'AI-подсказки',
-      'feature.ai.description': 'Получайте идеи от помощника',
-      'feature.calendarFeed.title': 'Лента календаря',
-      'feature.calendarFeed.description': 'Последние обновления из календаря',
-      'feature.callSetup.title': 'Начать звонок',
-      'feature.callSetup.description': 'Создайте аудио- или видеозвонок',
-      'feature.cloudCall.title': 'Облачный звонок',
-      'feature.cloudCall.description': 'Подключайтесь к общему лобби звонка',
+    'homeHubTitle': {
+      'en': 'Family App Hub',
+      'ru': 'Центр семейного приложения',
+      'de': 'Familien-App-Hub',
+      'fr': 'Accueil de l’application familiale',
+      'es': 'Centro de la aplicación familiar',
+      'zh': '家庭应用中心',
+    },
+    'drawerTitle': {
+      'en': 'Family App',
+      'ru': 'Family App',
+      'de': 'Family App',
+      'fr': 'Family App',
+      'es': 'Family App',
+      'zh': '家庭应用',
+    },
+    'languageMenuTitle': {
+      'en': 'Language',
+      'ru': 'Язык',
+      'de': 'Sprache',
+      'fr': 'Langue',
+      'es': 'Idioma',
+      'zh': '语言',
+    },
+    'languageMenuSubtitle': {
+      'en': 'Choose interface language',
+      'ru': 'Выберите язык интерфейса',
+      'de': 'Sprache der Oberfläche wählen',
+      'fr': 'Choisissez la langue de l’interface',
+      'es': 'Elija el idioma de la interfaz',
+      'zh': '选择界面语言',
+    },
+    'languageEnglish': {
+      'en': 'English',
+      'ru': 'Английский',
+      'de': 'Englisch',
+      'fr': 'Anglais',
+      'es': 'Inglés',
+      'zh': '英语',
+    },
+    'languageRussian': {
+      'en': 'Russian',
+      'ru': 'Русский',
+      'de': 'Russisch',
+      'fr': 'Russe',
+      'es': 'Ruso',
+      'zh': '俄语',
+    },
+    'languageGerman': {
+      'en': 'German',
+      'ru': 'Немецкий',
+      'de': 'Deutsch',
+      'fr': 'Allemand',
+      'es': 'Alemán',
+      'zh': '德语',
+    },
+    'languageFrench': {
+      'en': 'French',
+      'ru': 'Французский',
+      'de': 'Französisch',
+      'fr': 'Français',
+      'es': 'Francés',
+      'zh': '法语',
+    },
+    'languageSpanish': {
+      'en': 'Spanish',
+      'ru': 'Испанский',
+      'de': 'Spanisch',
+      'fr': 'Espagnol',
+      'es': 'Español',
+      'zh': '西班牙语',
+    },
+    'languageChinese': {
+      'en': 'Chinese',
+      'ru': 'Китайский',
+      'de': 'Chinesisch',
+      'fr': 'Chinois',
+      'es': 'Chino',
+      'zh': '中文',
+    },
+    'loading': {
+      'en': 'Loading…',
+      'ru': 'Загрузка…',
+      'de': 'Laden …',
+      'fr': 'Chargement…',
+      'es': 'Cargando…',
+      'zh': '加载中…',
+    },
+    'retry': {
+      'en': 'Retry',
+      'ru': 'Повторить',
+      'de': 'Erneut versuchen',
+      'fr': 'Réessayer',
+      'es': 'Reintentar',
+      'zh': '重试',
+    },
+    'errorLoadingData': {
+      'en': 'Could not load data',
+      'ru': 'Не удалось загрузить данные',
+      'de': 'Daten konnten nicht geladen werden',
+      'fr': 'Impossible de charger les données',
+      'es': 'No se pudieron cargar los datos',
+      'zh': '无法加载数据',
+    },
+    'members': {
+      'en': 'Members',
+      'ru': 'Участники',
+      'de': 'Mitglieder',
+      'fr': 'Membres',
+      'es': 'Miembros',
+      'zh': '成员',
+    },
+    'membersDescription': {
+      'en': 'Manage family members and view details',
+      'ru': 'Управляйте участниками семьи и просматривайте детали',
+      'de': 'Familienmitglieder verwalten und Details ansehen',
+      'fr': 'Gérez les membres de la famille et consultez les détails',
+      'es': 'Gestione a los miembros de la familia y vea los detalles',
+      'zh': '管理家庭成员并查看详细信息',
+    },
+    'tasks': {
+      'en': 'Tasks',
+      'ru': 'Задачи',
+      'de': 'Aufgaben',
+      'fr': 'Tâches',
+      'es': 'Tareas',
+      'zh': '任务',
+    },
+    'tasksDescription': {
+      'en': 'Assign chores and track status',
+      'ru': 'Назначайте дела и отслеживайте их статус',
+      'de': 'Aufgaben zuteilen und Fortschritt verfolgen',
+      'fr': 'Attribuez les tâches et suivez leur statut',
+      'es': 'Asigne tareas y haga seguimiento del estado',
+      'zh': '分配任务并跟踪状态',
+    },
+    'events': {
+      'en': 'Events',
+      'ru': 'События',
+      'de': 'Veranstaltungen',
+      'fr': 'Événements',
+      'es': 'Eventos',
+      'zh': '活动',
+    },
+    'eventsDescription': {
+      'en': 'Plan family events and gatherings',
+      'ru': 'Планируйте семейные мероприятия и встречи',
+      'de': 'Familienveranstaltungen und Treffen planen',
+      'fr': 'Planifiez les événements et réunions de famille',
+      'es': 'Planifique eventos y reuniones familiares',
+      'zh': '计划家庭活动和聚会',
+    },
+    'calendar': {
+      'en': 'Calendar',
+      'ru': 'Календарь',
+      'de': 'Kalender',
+      'fr': 'Calendrier',
+      'es': 'Calendario',
+      'zh': '日历',
+    },
+    'calendarDescription': {
+      'en': 'Overview of upcoming events and tasks',
+      'ru': 'Обзор предстоящих событий и задач',
+      'de': 'Überblick über kommende Ereignisse und Aufgaben',
+      'fr': 'Aperçu des événements et tâches à venir',
+      'es': 'Resumen de eventos y tareas próximos',
+      'zh': '即将发生的事件和任务概览',
+    },
+    'schedule': {
+      'en': 'Schedule',
+      'ru': 'Расписание',
+      'de': 'Zeitplan',
+      'fr': 'Agenda',
+      'es': 'Agenda',
+      'zh': '日程',
+    },
+    'scheduleDescription': {
+      'en': 'Personal schedule and agenda',
+      'ru': 'Личное расписание и дела',
+      'de': 'Persönlicher Zeitplan und Agenda',
+      'fr': 'Agenda personnelle',
+      'es': 'Agenda personal',
+      'zh': '个人日程',
+    },
+    'scoreboard': {
+      'en': 'Scoreboard',
+      'ru': 'Таблица очков',
+      'de': 'Bestenliste',
+      'fr': 'Tableau des scores',
+      'es': 'Marcador',
+      'zh': '积分榜',
+    },
+    'scoreboardDescription': {
+      'en': 'Gamify tasks with points',
+      'ru': 'Геймифицируйте задачи с помощью очков',
+      'de': 'Gamification der Aufgaben mit Punkten',
+      'fr': 'Gamifiez les tâches avec des points',
+      'es': 'Gamifique las tareas con puntos',
+      'zh': '用积分让任务游戏化',
+    },
+    'gallery': {
+      'en': 'Gallery',
+      'ru': 'Галерея',
+      'de': 'Galerie',
+      'fr': 'Galerie',
+      'es': 'Galería',
+      'zh': '图库',
+    },
+    'galleryDescription': {
+      'en': 'Family photos and memories',
+      'ru': 'Семейные фото и воспоминания',
+      'de': 'Familienfotos und Erinnerungen',
+      'fr': 'Photos et souvenirs de famille',
+      'es': 'Fotos y recuerdos familiares',
+      'zh': '家庭照片与回忆',
+    },
+    'friends': {
+      'en': 'Friends',
+      'ru': 'Друзья',
+      'de': 'Freunde',
+      'fr': 'Amis',
+      'es': 'Amigos',
+      'zh': '朋友',
+    },
+    'friendsDescription': {
+      'en': 'Keep track of friends of the family',
+      'ru': 'Следите за друзьями семьи',
+      'de': 'Freunde der Familie im Blick behalten',
+      'fr': 'Suivez les amis de la famille',
+      'es': 'Lleve un registro de los amigos de la familia',
+      'zh': '跟踪家庭朋友',
+    },
+    'chats': {
+      'en': 'Chats',
+      'ru': 'Чаты',
+      'de': 'Chats',
+      'fr': 'Discussions',
+      'es': 'Chats',
+      'zh': '聊天',
+    },
+    'chatsDescription': {
+      'en': 'Group and private conversations',
+      'ru': 'Групповые и личные беседы',
+      'de': 'Gruppen- und Privatgespräche',
+      'fr': 'Conversations de groupe et privées',
+      'es': 'Conversaciones grupales y privadas',
+      'zh': '群聊与私聊',
+    },
+    'aiSuggestions': {
+      'en': 'AI suggestions',
+      'ru': 'AI-подсказки',
+      'de': 'KI-Vorschläge',
+      'fr': 'Suggestions IA',
+      'es': 'Sugerencias de IA',
+      'zh': 'AI 建议',
+    },
+    'aiSuggestionsDescription': {
+      'en': 'Get ideas from the assistant',
+      'ru': 'Получайте идеи от помощника',
+      'de': 'Ideen vom Assistenten erhalten',
+      'fr': 'Obtenez des idées de l’assistant',
+      'es': 'Obtenga ideas del asistente',
+      'zh': '从助手获取灵感',
+    },
+    'calendarFeed': {
+      'en': 'Calendar feed',
+      'ru': 'Лента календаря',
+      'de': 'Kalender-Feed',
+      'fr': 'Flux du calendrier',
+      'es': 'Feed del calendario',
+      'zh': '日历动态',
+    },
+    'calendarFeedDescription': {
+      'en': 'Latest updates from the calendar',
+      'ru': 'Последние обновления календаря',
+      'de': 'Neueste Kalenderaktualisierungen',
+      'fr': 'Dernières mises à jour du calendrier',
+      'es': 'Últimas actualizaciones del calendario',
+      'zh': '来自日历的最新更新',
+    },
+    'startCall': {
+      'en': 'Start a call',
+      'ru': 'Начать звонок',
+      'de': 'Anruf starten',
+      'fr': 'Démarrer un appel',
+      'es': 'Iniciar una llamada',
+      'zh': '发起通话',
+    },
+    'startCallDescription': {
+      'en': 'Create an audio or video call',
+      'ru': 'Создайте аудио- или видеозвонок',
+      'de': 'Audio- oder Videoanruf starten',
+      'fr': 'Créer un appel audio ou vidéo',
+      'es': 'Cree una llamada de audio o video',
+      'zh': '创建音频或视频通话',
+    },
+    'cloudCall': {
+      'en': 'Cloud call',
+      'ru': 'Облачный звонок',
+      'de': 'Cloud-Anruf',
+      'fr': 'Appel cloud',
+      'es': 'Llamada en la nube',
+      'zh': '云通话',
+    },
+    'cloudCallDescription': {
+      'en': 'Join the cloud call lobby',
+      'ru': 'Присоединяйтесь к лобби облачного звонка',
+      'de': 'Der Cloud-Anruf-Lobby beitreten',
+      'fr': 'Rejoignez le salon d’appel cloud',
+      'es': 'Únase al lobby de la llamada en la nube',
+      'zh': '加入云通话大厅',
+    },
+    'saveAction': {
+      'en': 'Save',
+      'ru': 'Сохранить',
+      'de': 'Speichern',
+      'fr': 'Enregistrer',
+      'es': 'Guardar',
+      'zh': '保存',
+    },
+    'saveChanges': {
+      'en': 'Save changes',
+      'ru': 'Сохранить изменения',
+      'de': 'Änderungen speichern',
+      'fr': 'Enregistrer les modifications',
+      'es': 'Guardar cambios',
+      'zh': '保存更改',
+    },
+    'cancelAction': {
+      'en': 'Cancel',
+      'ru': 'Отмена',
+      'de': 'Abbrechen',
+      'fr': 'Annuler',
+      'es': 'Cancelar',
+      'zh': '取消',
+    },
+    'deleteAction': {
+      'en': 'Delete',
+      'ru': 'Удалить',
+      'de': 'Löschen',
+      'fr': 'Supprimer',
+      'es': 'Eliminar',
+      'zh': '删除',
+    },
+    'editAction': {
+      'en': 'Edit',
+      'ru': 'Редактировать',
+      'de': 'Bearbeiten',
+      'fr': 'Modifier',
+      'es': 'Editar',
+      'zh': '编辑',
+    },
+    'addMember': {
+      'en': 'Add member',
+      'ru': 'Добавить участника',
+      'de': 'Mitglied hinzufügen',
+      'fr': 'Ajouter un membre',
+      'es': 'Agregar miembro',
+      'zh': '添加成员',
+    },
+    'addTaskTitle': {
+      'en': 'Add task',
+      'ru': 'Добавить задачу',
+      'de': 'Aufgabe hinzufügen',
+      'fr': 'Ajouter une tâche',
+      'es': 'Agregar tarea',
+      'zh': '添加任务',
+    },
+    'addEventTitle': {
+      'en': 'Add event',
+      'ru': 'Добавить событие',
+      'de': 'Ereignis hinzufügen',
+      'fr': 'Ajouter un événement',
+      'es': 'Agregar evento',
+      'zh': '添加事件',
+    },
+    'addFriendTitle': {
+      'en': 'Add friend',
+      'ru': 'Добавить друга',
+      'de': 'Freund hinzufügen',
+      'fr': 'Ajouter un ami',
+      'es': 'Agregar amigo',
+      'zh': '添加好友',
+    },
+    'addGalleryItemTitle': {
+      'en': 'Add gallery item',
+      'ru': 'Добавить элемент галереи',
+      'de': 'Galerieelement hinzufügen',
+      'fr': 'Ajouter un élément à la galerie',
+      'es': 'Agregar elemento a la galería',
+      'zh': '添加图库项目',
+    },
+    'addScheduleItemTitle': {
+      'en': 'Add schedule item',
+      'ru': 'Добавить событие в расписание',
+      'de': 'Termin hinzufügen',
+      'fr': 'Ajouter un élément à l’agenda',
+      'es': 'Agregar elemento de agenda',
+      'zh': '添加日程条目',
+    },
+    'addDocumentEntry': {
+      'en': 'Add document',
+      'ru': 'Добавить документ',
+      'de': 'Dokument hinzufügen',
+      'fr': 'Ajouter un document',
+      'es': 'Agregar documento',
+      'zh': '添加文档',
+    },
+    'addSocialEntry': {
+      'en': 'Add social network',
+      'ru': 'Добавить соцсеть',
+      'de': 'Soziales Netzwerk hinzufügen',
+      'fr': 'Ajouter un réseau social',
+      'es': 'Agregar red social',
+      'zh': '添加社交网络',
+    },
+    'addMessengerEntry': {
+      'en': 'Add messenger',
+      'ru': 'Добавить мессенджер',
+      'de': 'Messenger hinzufügen',
+      'fr': 'Ajouter une messagerie',
+      'es': 'Agregar mensajero',
+      'zh': '添加即时通讯工具',
+    },
+    'saveEventAction': {
+      'en': 'Save event',
+      'ru': 'Сохранить событие',
+      'de': 'Ereignis speichern',
+      'fr': 'Enregistrer l’événement',
+      'es': 'Guardar evento',
+      'zh': '保存事件',
+    },
+    'saveScheduleItemAction': {
+      'en': 'Save schedule item',
+      'ru': 'Сохранить событие',
+      'de': 'Termin speichern',
+      'fr': 'Enregistrer l’élément',
+      'es': 'Guardar elemento',
+      'zh': '保存日程条目',
+    },
+    'selectDate': {
+      'en': 'Select date',
+      'ru': 'Выбрать дату',
+      'de': 'Datum auswählen',
+      'fr': 'Sélectionner une date',
+      'es': 'Seleccionar fecha',
+      'zh': '选择日期',
+    },
+    'selectAvatar': {
+      'en': 'Select avatar',
+      'ru': 'Выбрать аватар',
+      'de': 'Avatar auswählen',
+      'fr': 'Sélectionner un avatar',
+      'es': 'Seleccionar avatar',
+      'zh': '选择头像',
+    },
+    'selectMediaButton': {
+      'en': 'Select media',
+      'ru': 'Выбрать медиафайл',
+      'de': 'Medien auswählen',
+      'fr': 'Sélectionner un média',
+      'es': 'Seleccionar archivo',
+      'zh': '选择媒体',
+    },
+    'uploadingLabel': {
+      'en': 'Uploading…',
+      'ru': 'Загрузка…',
+      'de': 'Wird hochgeladen…',
+      'fr': 'Téléchargement…',
+      'es': 'Subiendo…',
+      'zh': '正在上传…',
+    },
+    'fileReadyLabel': {
+      'en': 'File ready',
+      'ru': 'Файл готов',
+      'de': 'Datei bereit',
+      'fr': 'Fichier prêt',
+      'es': 'Archivo listo',
+      'zh': '文件已就绪',
+    },
+    'galleryNoFileSelected': {
+      'en': 'No file selected',
+      'ru': 'Файл не выбран',
+      'de': 'Keine Datei ausgewählt',
+      'fr': 'Aucun fichier sélectionné',
+      'es': 'Ningún archivo seleccionado',
+      'zh': '未选择文件',
+    },
+    'galleryEmpty': {
+      'en': 'No gallery items yet',
+      'ru': 'В галерее пока пусто',
+      'de': 'Noch keine Galerieelemente',
+      'fr': 'Aucun élément dans la galerie',
+      'es': 'Aún no hay elementos en la galería',
+      'zh': '暂无图库内容',
+    },
+    'avatarNotSelected': {
+      'en': 'No avatar selected',
+      'ru': 'Аватар не выбран',
+      'de': 'Kein Avatar ausgewählt',
+      'fr': 'Aucun avatar sélectionné',
+      'es': 'Avatar no seleccionado',
+      'zh': '未选择头像',
+    },
+    'avatarUploading': {
+      'en': 'Uploading avatar…',
+      'ru': 'Загрузка аватара…',
+      'de': 'Avatar wird hochgeladen…',
+      'fr': 'Téléversement de l’avatar…',
+      'es': 'Subiendo avatar…',
+      'zh': '头像上传中…',
+    },
+    'additionalInfoSection': {
+      'en': 'Additional information',
+      'ru': 'Дополнительная информация',
+      'de': 'Weitere Informationen',
+      'fr': 'Informations complémentaires',
+      'es': 'Información adicional',
+      'zh': '附加信息',
+    },
+    'contactsSection': {
+      'en': 'Contacts',
+      'ru': 'Контакты',
+      'de': 'Kontakte',
+      'fr': 'Contacts',
+      'es': 'Contactos',
+      'zh': '联系方式',
+    },
+    'socialNetworksSection': {
+      'en': 'Social networks',
+      'ru': 'Социальные сети',
+      'de': 'Soziale Netzwerke',
+      'fr': 'Réseaux sociaux',
+      'es': 'Redes sociales',
+      'zh': '社交网络',
+    },
+    'messengersSection': {
+      'en': 'Messengers',
+      'ru': 'Мессенджеры',
+      'de': 'Messenger',
+      'fr': 'Messageries',
+      'es': 'Mensajeros',
+      'zh': '即时通讯',
+    },
+    'documentsSection': {
+      'en': 'Documents',
+      'ru': 'Документы',
+      'de': 'Dokumente',
+      'fr': 'Documents',
+      'es': 'Documentos',
+      'zh': '证件',
+    },
+    'documentsSummaryLabel': {
+      'en': 'Documents summary',
+      'ru': 'Сводка документов',
+      'de': 'Dokumentenzusammenfassung',
+      'fr': 'Résumé des documents',
+      'es': 'Resumen de documentos',
+      'zh': '文件摘要',
+    },
+    'documentsHint': {
+      'en': 'List important documents here',
+      'ru': 'Перечислите важные документы',
+      'de': 'Wichtige Dokumente hier auflisten',
+      'fr': 'Répertoriez ici les documents importants',
+      'es': 'Enumere aquí los documentos importantes',
+      'zh': '在此列出重要文件',
+    },
+    'socialSummaryLabel': {
+      'en': 'Social overview',
+      'ru': 'Соцсети',
+      'de': 'Social-Media-Übersicht',
+      'fr': 'Aperçu des réseaux sociaux',
+      'es': 'Resumen social',
+      'zh': '社交概览',
+    },
+    'fieldName': {
+      'en': 'Name',
+      'ru': 'Имя',
+      'de': 'Name',
+      'fr': 'Nom',
+      'es': 'Nombre',
+      'zh': '姓名',
+    },
+    'fieldRelationship': {
+      'en': 'Relationship',
+      'ru': 'Отношения',
+      'de': 'Beziehung',
+      'fr': 'Relation',
+      'es': 'Relación',
+      'zh': '关系',
+    },
+    'fieldPhone': {
+      'en': 'Phone',
+      'ru': 'Телефон',
+      'de': 'Telefon',
+      'fr': 'Téléphone',
+      'es': 'Teléfono',
+      'zh': '电话',
+    },
+    'fieldEmail': {
+      'en': 'Email',
+      'ru': 'Email',
+      'de': 'E-Mail',
+      'fr': 'E-mail',
+      'es': 'Correo electrónico',
+      'zh': '电子邮件',
+    },
+    'fieldHobbies': {
+      'en': 'Hobbies',
+      'ru': 'Увлечения',
+      'de': 'Hobbys',
+      'fr': 'Loisirs',
+      'es': 'Aficiones',
+      'zh': '爱好',
+    },
+    'hobbiesHint': {
+      'en': 'Describe hobbies, interests and skills',
+      'ru': 'Опишите увлечения, интересы и навыки',
+      'de': 'Beschreiben Sie Hobbys, Interessen und Fähigkeiten',
+      'fr': 'Décrivez les loisirs, intérêts et compétences',
+      'es': 'Describa aficiones, intereses y habilidades',
+      'zh': '描述爱好、兴趣和技能',
+    },
+    'documentTypeLabel': {
+      'en': 'Document type',
+      'ru': 'Тип документа',
+      'de': 'Dokumenttyp',
+      'fr': 'Type de document',
+      'es': 'Tipo de documento',
+      'zh': '证件类型',
+    },
+    'documentValueLabel': {
+      'en': 'Details',
+      'ru': 'Детали',
+      'de': 'Details',
+      'fr': 'Détails',
+      'es': 'Detalles',
+      'zh': '详情',
+    },
+    'socialValueLabel': {
+      'en': 'Profile / link',
+      'ru': 'Профиль / ссылка',
+      'de': 'Profil / Link',
+      'fr': 'Profil / lien',
+      'es': 'Perfil / enlace',
+      'zh': '个人资料/链接',
+    },
+    'messengerValueLabel': {
+      'en': 'Username / number',
+      'ru': 'Имя пользователя / номер',
+      'de': 'Benutzername / Nummer',
+      'fr': 'Identifiant / numéro',
+      'es': 'Usuario / número',
+      'zh': '用户名/号码',
+    },
+    'validationEnterName': {
+      'en': 'Please enter a name',
+      'ru': 'Пожалуйста, введите имя',
+      'de': 'Bitte einen Namen eingeben',
+      'fr': 'Veuillez saisir un nom',
+      'es': 'Ingrese un nombre',
+      'zh': '请输入姓名',
+    },
+    'validationEnterTitle': {
+      'en': 'Please enter a title',
+      'ru': 'Пожалуйста, введите название',
+      'de': 'Bitte geben Sie einen Titel ein',
+      'fr': 'Veuillez saisir un titre',
+      'es': 'Ingrese un título',
+      'zh': '请输入标题',
+    },
+    'birthdayLabel': {
+      'en': 'Birthday',
+      'ru': 'День рождения',
+      'de': 'Geburtstag',
+      'fr': 'Anniversaire',
+      'es': 'Cumpleaños',
+      'zh': '生日',
+    },
+    'birthdayNotSet': {
+      'en': 'Birthday not set',
+      'ru': 'Дата рождения не указана',
+      'de': 'Geburtstag nicht festgelegt',
+      'fr': 'Anniversaire non défini',
+      'es': 'Cumpleaños no establecido',
+      'zh': '生日未设置',
+    },
+    'birthdayWithDate': {
+      'en': 'Birthday: {date}',
+      'ru': 'День рождения: {date}',
+      'de': 'Geburtstag: {date}',
+      'fr': 'Anniversaire : {date}',
+      'es': 'Cumpleaños: {date}',
+      'zh': '生日：{date}',
+    },
+    'memberTitle': {
+      'en': 'Member',
+      'ru': 'Участник',
+      'de': 'Mitglied',
+      'fr': 'Membre',
+      'es': 'Miembro',
+      'zh': '成员',
+    },
+    'memberNotFound': {
+      'en': 'Member not found',
+      'ru': 'Участник не найден',
+      'de': 'Mitglied nicht gefunden',
+      'fr': 'Membre introuvable',
+      'es': 'Miembro no encontrado',
+      'zh': '未找到成员',
+    },
+    'memberFallback': {
+      'en': 'Family member',
+      'ru': 'Член семьи',
+      'de': 'Familienmitglied',
+      'fr': 'Membre de la famille',
+      'es': 'Miembro de la familia',
+      'zh': '家庭成员',
+    },
+    'viewDocuments': {
+      'en': 'View documents',
+      'ru': 'Просмотреть документы',
+      'de': 'Dokumente ansehen',
+      'fr': 'Voir les documents',
+      'es': 'Ver documentos',
+      'zh': '查看文件',
+    },
+    'editDocumentsAction': {
+      'en': 'Edit documents',
+      'ru': 'Редактировать документы',
+      'de': 'Dokumente bearbeiten',
+      'fr': 'Modifier les documents',
+      'es': 'Editar documentos',
+      'zh': '编辑文件',
+    },
+    'viewHobbiesAction': {
+      'en': 'View hobbies',
+      'ru': 'Просмотреть увлечения',
+      'de': 'Hobbys anzeigen',
+      'fr': 'Voir les loisirs',
+      'es': 'Ver aficiones',
+      'zh': '查看爱好',
+    },
+    'editHobbiesAction': {
+      'en': 'Edit hobbies',
+      'ru': 'Редактировать увлечения',
+      'de': 'Hobbys bearbeiten',
+      'fr': 'Modifier les loisirs',
+      'es': 'Editar aficiones',
+      'zh': '编辑爱好',
+    },
+    'memberDocumentsTitle': {
+      'en': 'Documents – {name}',
+      'ru': 'Документы — {name}',
+      'de': 'Dokumente – {name}',
+      'fr': 'Documents – {name}',
+      'es': 'Documentos – {name}',
+      'zh': '文件 – {name}',
+    },
+    'participantsLabel': {
+      'en': 'Participants',
+      'ru': 'Участники',
+      'de': 'Teilnehmende',
+      'fr': 'Participants',
+      'es': 'Participantes',
+      'zh': '参与者',
+    },
+    'noMembersForParticipants': {
+      'en': 'No members available to invite',
+      'ru': 'Нет участников для приглашения',
+      'de': 'Keine Mitglieder zum Einladen verfügbar',
+      'fr': 'Aucun membre à inviter',
+      'es': 'No hay miembros disponibles para invitar',
+      'zh': '没有可邀请的成员',
+    },
+    'noMembersForCall': {
+      'en': 'No members available for the call',
+      'ru': 'Нет участников для звонка',
+      'de': 'Keine Mitglieder für den Anruf verfügbar',
+      'fr': 'Aucun membre disponible pour l’appel',
+      'es': 'No hay miembros disponibles para la llamada',
+      'zh': '没有可通话的成员',
+    },
+    'noMembersForChat': {
+      'en': 'No members available for chat',
+      'ru': 'Нет участников для чата',
+      'de': 'Keine Mitglieder für den Chat verfügbar',
+      'fr': 'Aucun membre disponible pour le chat',
+      'es': 'No hay miembros disponibles para el chat',
+      'zh': '没有可聊天的成员',
+    },
+    'selectParticipantsError': {
+      'en': 'Select at least one participant',
+      'ru': 'Выберите хотя бы одного участника',
+      'de': 'Wählen Sie mindestens eine Person aus',
+      'fr': 'Sélectionnez au moins un participant',
+      'es': 'Seleccione al menos un participante',
+      'zh': '至少选择一位参与者',
+    },
+    'selectStartLabel': {
+      'en': 'Select start',
+      'ru': 'Выбрать начало',
+      'de': 'Beginn wählen',
+      'fr': 'Sélectionner le début',
+      'es': 'Seleccionar inicio',
+      'zh': '选择开始时间',
+    },
+    'selectEndLabel': {
+      'en': 'Select end',
+      'ru': 'Выбрать окончание',
+      'de': 'Ende wählen',
+      'fr': 'Sélectionner la fin',
+      'es': 'Seleccionar fin',
+      'zh': '选择结束时间',
+    },
+    'noMemberOption': {
+      'en': 'Unassigned',
+      'ru': 'Без назначения',
+      'de': 'Nicht zugewiesen',
+      'fr': 'Non assigné',
+      'es': 'Sin asignar',
+      'zh': '未指定',
+    },
+    'noNameLabel': {
+      'en': 'No name',
+      'ru': 'Без имени',
+      'de': 'Kein Name',
+      'fr': 'Sans nom',
+      'es': 'Sin nombre',
+      'zh': '无姓名',
+    },
+    'noMembersLabel': {
+      'en': 'No members yet',
+      'ru': 'Участников пока нет',
+      'de': 'Noch keine Mitglieder',
+      'fr': 'Aucun membre pour le moment',
+      'es': 'Aún no hay miembros',
+      'zh': '暂无成员',
+    },
+    'noFriendsLabel': {
+      'en': 'No friends yet',
+      'ru': 'Друзей пока нет',
+      'de': 'Noch keine Freunde',
+      'fr': 'Aucun ami pour le moment',
+      'es': 'Aún no hay amigos',
+      'zh': '暂无好友',
+    },
+    'noTasksLabel': {
+      'en': 'No tasks yet',
+      'ru': 'Задач пока нет',
+      'de': 'Noch keine Aufgaben',
+      'fr': 'Aucune tâche pour le moment',
+      'es': 'Aún no hay tareas',
+      'zh': '暂无任务',
+    },
+    'noEventsLabel': {
+      'en': 'No events yet',
+      'ru': 'Событий пока нет',
+      'de': 'Noch keine Ereignisse',
+      'fr': 'Aucun événement pour le moment',
+      'es': 'Aún no hay eventos',
+      'zh': '暂无事件',
+    },
+    'noScheduleItemsLabel': {
+      'en': 'No schedule items yet',
+      'ru': 'В расписании пока пусто',
+      'de': 'Noch keine Termine',
+      'fr': 'Aucun élément d’agenda',
+      'es': 'Aún no hay elementos de agenda',
+      'zh': '暂无日程项目',
+    },
+    'noChatsLabel': {
+      'en': 'No chats yet',
+      'ru': 'Чатов пока нет',
+      'de': 'Noch keine Chats',
+      'fr': 'Aucun chat pour le moment',
+      'es': 'Aún no hay chats',
+      'zh': '暂无聊天',
+    },
+    'noMessagesLabel': {
+      'en': 'No messages yet',
+      'ru': 'Сообщений пока нет',
+      'de': 'Noch keine Nachrichten',
+      'fr': 'Aucun message pour le moment',
+      'es': 'Aún no hay mensajes',
+      'zh': '暂无消息',
+    },
+    'noDocumentsLabel': {
+      'en': 'No documents yet',
+      'ru': 'Документов пока нет',
+      'de': 'Noch keine Dokumente',
+      'fr': 'Aucun document pour le moment',
+      'es': 'Aún no hay documentos',
+      'zh': '暂无文档',
+    },
+    'noActiveCallLabel': {
+      'en': 'No active call',
+      'ru': 'Активных звонков нет',
+      'de': 'Kein aktiver Anruf',
+      'fr': 'Aucun appel en cours',
+      'es': 'No hay llamadas activas',
+      'zh': '暂无进行中的通话',
+    },
+    'noCalendarFeedLabel': {
+      'en': 'No calendar feed available',
+      'ru': 'Лента календаря недоступна',
+      'de': 'Kein Kalender-Feed verfügbar',
+      'fr': 'Aucun flux de calendrier disponible',
+      'es': 'No hay feed de calendario disponible',
+      'zh': '暂无日历动态',
+    },
+    'noCalendarItemsLabel': {
+      'en': 'No upcoming events or tasks',
+      'ru': 'Нет предстоящих событий или задач',
+      'de': 'Keine anstehenden Ereignisse oder Aufgaben',
+      'fr': 'Aucun événement ou tâche à venir',
+      'es': 'No hay eventos ni tareas próximos',
+      'zh': '暂无即将发生的事件或任务',
+    },
+    'noDueDate': {
+      'en': 'No due date',
+      'ru': 'Без срока',
+      'de': 'Kein Fälligkeitsdatum',
+      'fr': 'Pas d’échéance',
+      'es': 'Sin fecha límite',
+      'zh': '无到期日',
+    },
+    'notSetLabel': {
+      'en': 'Not set',
+      'ru': 'Не указано',
+      'de': 'Nicht festgelegt',
+      'fr': 'Non défini',
+      'es': 'Sin definir',
+      'zh': '未设置',
+    },
+    'dateNotSet': {
+      'en': 'Date not set',
+      'ru': 'Дата не указана',
+      'de': 'Datum nicht festgelegt',
+      'fr': 'Date non définie',
+      'es': 'Fecha no establecida',
+      'zh': '日期未设置',
+    },
+    'participantsListLabel': {
+      'en': 'Participants: {names}',
+      'ru': 'Участники: {names}',
+      'de': 'Teilnehmende: {names}',
+      'fr': 'Participants : {names}',
+      'es': 'Participantes: {names}',
+      'zh': '参与者：{names}',
+    },
+    'documentType.passport': {
+      'en': 'Passport',
+      'ru': 'Паспорт',
+      'de': 'Reisepass',
+      'fr': 'Passeport',
+      'es': 'Pasaporte',
+      'zh': '护照',
+    },
+    'documentType.driverLicense': {
+      'en': 'Driver license',
+      'ru': 'Водительское удостоверение',
+      'de': 'Führerschein',
+      'fr': 'Permis de conduire',
+      'es': 'Licencia de conducir',
+      'zh': '驾驶证',
+    },
+    'documentType.birthCertificate': {
+      'en': 'Birth certificate',
+      'ru': 'Свидетельство о рождении',
+      'de': 'Geburtsurkunde',
+      'fr': 'Acte de naissance',
+      'es': 'Certificado de nacimiento',
+      'zh': '出生证明',
+    },
+    'documentType.insurancePolicy': {
+      'en': 'Insurance policy',
+      'ru': 'Страховой полис',
+      'de': 'Versicherungspolice',
+      'fr': 'Police d’assurance',
+      'es': 'Póliza de seguro',
+      'zh': '保险单',
+    },
+    'documentType.idCard': {
+      'en': 'ID card',
+      'ru': 'Удостоверение личности',
+      'de': 'Personalausweis',
+      'fr': 'Carte d’identité',
+      'es': 'Documento de identidad',
+      'zh': '身份证',
+    },
+    'documentType.other': {
+      'en': 'Other document',
+      'ru': 'Другой документ',
+      'de': 'Anderes Dokument',
+      'fr': 'Autre document',
+      'es': 'Otro documento',
+      'zh': '其他证件',
+    },
+    'socialNetwork.facebook': {
+      'en': 'Facebook',
+      'ru': 'Facebook',
+      'de': 'Facebook',
+      'fr': 'Facebook',
+      'es': 'Facebook',
+      'zh': 'Facebook',
+    },
+    'socialNetwork.instagram': {
+      'en': 'Instagram',
+      'ru': 'Instagram',
+      'de': 'Instagram',
+      'fr': 'Instagram',
+      'es': 'Instagram',
+      'zh': 'Instagram',
+    },
+    'socialNetwork.vk': {
+      'en': 'VK',
+      'ru': 'ВКонтакте',
+      'de': 'VK',
+      'fr': 'VK',
+      'es': 'VK',
+      'zh': 'VK',
+    },
+    'socialNetwork.linkedin': {
+      'en': 'LinkedIn',
+      'ru': 'LinkedIn',
+      'de': 'LinkedIn',
+      'fr': 'LinkedIn',
+      'es': 'LinkedIn',
+      'zh': 'LinkedIn',
+    },
+    'socialNetwork.tiktok': {
+      'en': 'TikTok',
+      'ru': 'TikTok',
+      'de': 'TikTok',
+      'fr': 'TikTok',
+      'es': 'TikTok',
+      'zh': '抖音 / TikTok',
+    },
+    'socialNetwork.youtube': {
+      'en': 'YouTube',
+      'ru': 'YouTube',
+      'de': 'YouTube',
+      'fr': 'YouTube',
+      'es': 'YouTube',
+      'zh': 'YouTube',
+    },
+    'socialNetwork.twitter': {
+      'en': 'Twitter',
+      'ru': 'Twitter',
+      'de': 'Twitter',
+      'fr': 'Twitter',
+      'es': 'Twitter',
+      'zh': 'Twitter',
+    },
+    'socialNetwork.other': {
+      'en': 'Other network',
+      'ru': 'Другая сеть',
+      'de': 'Anderes Netzwerk',
+      'fr': 'Autre réseau',
+      'es': 'Otra red',
+      'zh': '其他网络',
+    },
+    'messenger.whatsapp': {
+      'en': 'WhatsApp',
+      'ru': 'WhatsApp',
+      'de': 'WhatsApp',
+      'fr': 'WhatsApp',
+      'es': 'WhatsApp',
+      'zh': 'WhatsApp',
+    },
+    'messenger.telegram': {
+      'en': 'Telegram',
+      'ru': 'Telegram',
+      'de': 'Telegram',
+      'fr': 'Telegram',
+      'es': 'Telegram',
+      'zh': 'Telegram',
+    },
+    'messenger.signal': {
+      'en': 'Signal',
+      'ru': 'Signal',
+      'de': 'Signal',
+      'fr': 'Signal',
+      'es': 'Signal',
+      'zh': 'Signal',
+    },
+    'messenger.viber': {
+      'en': 'Viber',
+      'ru': 'Viber',
+      'de': 'Viber',
+      'fr': 'Viber',
+      'es': 'Viber',
+      'zh': 'Viber',
+    },
+    'messenger.wechat': {
+      'en': 'WeChat',
+      'ru': 'WeChat',
+      'de': 'WeChat',
+      'fr': 'WeChat',
+      'es': 'WeChat',
+      'zh': '微信',
+    },
+    'messenger.messenger': {
+      'en': 'Messenger',
+      'ru': 'Messenger',
+      'de': 'Messenger',
+      'fr': 'Messenger',
+      'es': 'Messenger',
+      'zh': 'Messenger',
+    },
+    'messenger.line': {
+      'en': 'LINE',
+      'ru': 'LINE',
+      'de': 'LINE',
+      'fr': 'LINE',
+      'es': 'LINE',
+      'zh': 'LINE',
+    },
+    'messenger.skype': {
+      'en': 'Skype',
+      'ru': 'Skype',
+      'de': 'Skype',
+      'fr': 'Skype',
+      'es': 'Skype',
+      'zh': 'Skype',
+    },
+    'messenger.other': {
+      'en': 'Other messenger',
+      'ru': 'Другой мессенджер',
+      'de': 'Anderer Messenger',
+      'fr': 'Autre messagerie',
+      'es': 'Otro mensajero',
+      'zh': '其他通讯工具',
+    },
+    'taskTitleLabel': {
+      'en': 'Task title',
+      'ru': 'Название задачи',
+      'de': 'Aufgabentitel',
+      'fr': 'Titre de la tâche',
+      'es': 'Título de la tarea',
+      'zh': '任务标题',
+    },
+    'taskDescriptionLabel': {
+      'en': 'Description',
+      'ru': 'Описание',
+      'de': 'Beschreibung',
+      'fr': 'Description',
+      'es': 'Descripción',
+      'zh': '描述',
+    },
+    'taskDueDate': {
+      'en': 'Due date',
+      'ru': 'Срок',
+      'de': 'Fälligkeitsdatum',
+      'fr': 'Date d’échéance',
+      'es': 'Fecha límite',
+      'zh': '截止日期',
+    },
+    'taskStatusLabel': {
+      'en': 'Status',
+      'ru': 'Статус',
+      'de': 'Status',
+      'fr': 'Statut',
+      'es': 'Estado',
+      'zh': '状态',
+    },
+    'assignToLabel': {
+      'en': 'Assign to',
+      'ru': 'Назначить',
+      'de': 'Zuweisen an',
+      'fr': 'Assigner à',
+      'es': 'Asignar a',
+      'zh': '分配给',
+    },
+    'rewardPointsLabel': {
+      'en': 'Reward points',
+      'ru': 'Очки награды',
+      'de': 'Punkte',
+      'fr': 'Points de récompense',
+      'es': 'Puntos de recompensa',
+      'zh': '奖励积分',
+    },
+    'rewardPointsHint': {
+      'en': 'Enter points for completing the task',
+      'ru': 'Укажите очки за выполнение задачи',
+      'de': 'Punkte für die Aufgabe eingeben',
+      'fr': 'Indiquez les points pour la tâche',
+      'es': 'Ingrese puntos por completar la tarea',
+      'zh': '输入完成任务的积分',
+    },
+    'markTodoAction': {
+      'en': 'Mark as to-do',
+      'ru': 'Пометить как «в планах»',
+      'de': 'Als offen markieren',
+      'fr': 'Marquer en à faire',
+      'es': 'Marcar como pendiente',
+      'zh': '标记为待办',
+    },
+    'markInProgressAction': {
+      'en': 'Mark in progress',
+      'ru': 'Пометить как выполняется',
+      'de': 'Als in Arbeit markieren',
+      'fr': 'Marquer en cours',
+      'es': 'Marcar en progreso',
+      'zh': '标记为进行中',
+    },
+    'markDoneAction': {
+      'en': 'Mark as done',
+      'ru': 'Пометить как выполнено',
+      'de': 'Als erledigt markieren',
+      'fr': 'Marquer comme terminé',
+      'es': 'Marcar como completado',
+      'zh': '标记为完成',
+    },
+    'deleteTaskAction': {
+      'en': 'Delete task',
+      'ru': 'Удалить задачу',
+      'de': 'Aufgabe löschen',
+      'fr': 'Supprimer la tâche',
+      'es': 'Eliminar tarea',
+      'zh': '删除任务',
+    },
+    'taskStatus.todo': {
+      'en': 'To-do',
+      'ru': 'В планах',
+      'de': 'Offen',
+      'fr': 'À faire',
+      'es': 'Pendiente',
+      'zh': '待办',
+    },
+    'taskStatus.inProgress': {
+      'en': 'In progress',
+      'ru': 'Выполняется',
+      'de': 'In Arbeit',
+      'fr': 'En cours',
+      'es': 'En progreso',
+      'zh': '进行中',
+    },
+    'taskStatus.done': {
+      'en': 'Done',
+      'ru': 'Выполнено',
+      'de': 'Erledigt',
+      'fr': 'Terminé',
+      'es': 'Completado',
+      'zh': '已完成',
+    },
+    'unassignedLabel': {
+      'en': 'Unassigned',
+      'ru': 'Не назначено',
+      'de': 'Nicht zugewiesen',
+      'fr': 'Non attribué',
+      'es': 'No asignado',
+      'zh': '未分配',
+    },
+    'dueLabel': {
+      'en': 'Due',
+      'ru': 'Срок',
+      'de': 'Fällig',
+      'fr': 'Échéance',
+      'es': 'Vence',
+      'zh': '到期',
+    },
+    'statusLabel': {
+      'en': 'Status',
+      'ru': 'Статус',
+      'de': 'Status',
+      'fr': 'Statut',
+      'es': 'Estado',
+      'zh': '状态',
+    },
+    'tasksSectionTitle': {
+      'en': 'Tasks',
+      'ru': 'Задачи',
+      'de': 'Aufgaben',
+      'fr': 'Tâches',
+      'es': 'Tareas',
+      'zh': '任务',
+    },
+    'pointsSuffix': {
+      'en': '{points} pts',
+      'ru': '{points} очков',
+      'de': '{points} Pkt.',
+      'fr': '{points} pts',
+      'es': '{points} pts',
+      'zh': '{points} 分',
+    },
+    'confirmDelete': {
+      'en': 'Delete {item}?',
+      'ru': 'Удалить {item}?',
+      'de': '{item} löschen?',
+      'fr': 'Supprimer {item} ?',
+      'es': '¿Eliminar {item}?',
+      'zh': '删除{item}？',
+    },
+    'scheduleTitleLabel': {
+      'en': 'Title',
+      'ru': 'Название',
+      'de': 'Titel',
+      'fr': 'Titre',
+      'es': 'Título',
+      'zh': '标题',
+    },
+    'scheduleDateTimeLabel': {
+      'en': 'Date & time',
+      'ru': 'Дата и время',
+      'de': 'Datum und Uhrzeit',
+      'fr': 'Date et heure',
+      'es': 'Fecha y hora',
+      'zh': '日期和时间',
+    },
+    'scheduleDurationLabel': {
+      'en': 'Duration',
+      'ru': 'Продолжительность',
+      'de': 'Dauer',
+      'fr': 'Durée',
+      'es': 'Duración',
+      'zh': '时长',
+    },
+    'scheduleDurationMinutes': {
+      'en': '{minutes} minutes',
+      'ru': '{minutes} минут',
+      'de': '{minutes} Minuten',
+      'fr': '{minutes} minutes',
+      'es': '{minutes} minutos',
+      'zh': '{minutes} 分钟',
+    },
+    'durationNotSpecified': {
+      'en': 'No duration',
+      'ru': 'Без длительности',
+      'de': 'Keine Dauer',
+      'fr': 'Aucune durée',
+      'es': 'Sin duración',
+      'zh': '无时长',
+    },
+    'scheduleMemberLabel': {
+      'en': 'Assigned to',
+      'ru': 'Назначено',
+      'de': 'Zugewiesen an',
+      'fr': 'Assigné à',
+      'es': 'Asignado a',
+      'zh': '分配给',
+    },
+    'scheduleLocationLabel': {
+      'en': 'Location',
+      'ru': 'Место',
+      'de': 'Ort',
+      'fr': 'Lieu',
+      'es': 'Ubicación',
+      'zh': '地点',
+    },
+    'scheduleNotesLabel': {
+      'en': 'Notes',
+      'ru': 'Заметки',
+      'de': 'Notizen',
+      'fr': 'Notes',
+      'es': 'Notas',
+      'zh': '备注',
+    },
+    'notesLabel': {
+      'en': 'Notes',
+      'ru': 'Заметки',
+      'de': 'Notizen',
+      'fr': 'Notes',
+      'es': 'Notas',
+      'zh': '备注',
+    },
+    'deleteScheduleAction': {
+      'en': 'Delete item',
+      'ru': 'Удалить событие',
+      'de': 'Eintrag löschen',
+      'fr': 'Supprimer l’élément',
+      'es': 'Eliminar elemento',
+      'zh': '删除条目',
+    },
+    'deleteScheduleMessage': {
+      'en': 'Remove this schedule entry?',
+      'ru': 'Удалить эту запись расписания?',
+      'de': 'Diesen Termineintrag entfernen?',
+      'fr': 'Supprimer cette entrée d’agenda ?',
+      'es': '¿Eliminar este elemento de agenda?',
+      'zh': '删除此日程条目？',
+    },
+    'eventTitleLabel': {
+      'en': 'Event title',
+      'ru': 'Название события',
+      'de': 'Ereignistitel',
+      'fr': 'Titre de l’événement',
+      'es': 'Título del evento',
+      'zh': '活动标题',
+    },
+    'eventDescriptionLabel': {
+      'en': 'Description',
+      'ru': 'Описание',
+      'de': 'Beschreibung',
+      'fr': 'Description',
+      'es': 'Descripción',
+      'zh': '描述',
+    },
+    'deleteEventAction': {
+      'en': 'Delete event',
+      'ru': 'Удалить событие',
+      'de': 'Ereignis löschen',
+      'fr': 'Supprimer l’événement',
+      'es': 'Eliminar evento',
+      'zh': '删除事件',
+    },
+    'createChatTitle': {
+      'en': 'Create chat',
+      'ru': 'Создать чат',
+      'de': 'Chat erstellen',
+      'fr': 'Créer une discussion',
+      'es': 'Crear chat',
+      'zh': '创建聊天',
+    },
+    'createChatAction': {
+      'en': 'Create chat',
+      'ru': 'Создать чат',
+      'de': 'Chat erstellen',
+      'fr': 'Créer une discussion',
+      'es': 'Crear chat',
+      'zh': '创建聊天',
+    },
+    'chatTitleLabel': {
+      'en': 'Chat title',
+      'ru': 'Название чата',
+      'de': 'Chat-Titel',
+      'fr': 'Titre du chat',
+      'es': 'Título del chat',
+      'zh': '聊天标题',
+    },
+    'chatTitleValidation': {
+      'en': 'Please enter a chat title',
+      'ru': 'Введите название чата',
+      'de': 'Bitte geben Sie einen Chat-Titel ein',
+      'fr': 'Veuillez saisir un titre de discussion',
+      'es': 'Ingrese un título de chat',
+      'zh': '请输入聊天标题',
+    },
+    'sendAction': {
+      'en': 'Send',
+      'ru': 'Отправить',
+      'de': 'Senden',
+      'fr': 'Envoyer',
+      'es': 'Enviar',
+      'zh': '发送',
+    },
+    'typeMessageHint': {
+      'en': 'Type a message',
+      'ru': 'Введите сообщение',
+      'de': 'Nachricht eingeben',
+      'fr': 'Saisissez un message',
+      'es': 'Escriba un mensaje',
+      'zh': '输入消息',
+    },
+    'senderLabel': {
+      'en': 'Sender',
+      'ru': 'Отправитель',
+      'de': 'Absender',
+      'fr': 'Expéditeur',
+      'es': 'Remitente',
+      'zh': '发送者',
+    },
+    'unknownMemberLabel': {
+      'en': 'Unknown member',
+      'ru': 'Неизвестный участник',
+      'de': 'Unbekanntes Mitglied',
+      'fr': 'Membre inconnu',
+      'es': 'Miembro desconocido',
+      'zh': '未知成员',
+    },
+    'deleteChatAction': {
+      'en': 'Delete chat',
+      'ru': 'Удалить чат',
+      'de': 'Chat löschen',
+      'fr': 'Supprimer la discussion',
+      'es': 'Eliminar chat',
+      'zh': '删除聊天',
+    },
+    'callDefaultTitle': {
+      'en': 'Family call',
+      'ru': 'Семейный звонок',
+      'de': 'Familienanruf',
+      'fr': 'Appel familial',
+      'es': 'Llamada familiar',
+      'zh': '家庭通话',
+    },
+    'callFallbackTitle': {
+      'en': 'Family call',
+      'ru': 'Семейный звонок',
+      'de': 'Familienanruf',
+      'fr': 'Appel familial',
+      'es': 'Llamada familiar',
+      'zh': '家庭通话',
+    },
+    'callTitleLabel': {
+      'en': 'Call title',
+      'ru': 'Название звонка',
+      'de': 'Anrufname',
+      'fr': 'Titre de l’appel',
+      'es': 'Título de la llamada',
+      'zh': '通话标题',
+    },
+    'callTypeLabel': {
+      'en': 'Call type',
+      'ru': 'Тип звонка',
+      'de': 'Anruftyp',
+      'fr': 'Type d’appel',
+      'es': 'Tipo de llamada',
+      'zh': '通话类型',
+    },
+    'audioLabel': {
+      'en': 'Audio',
+      'ru': 'Аудио',
+      'de': 'Audio',
+      'fr': 'Audio',
+      'es': 'Audio',
+      'zh': '音频',
+    },
+    'videoLabel': {
+      'en': 'Video',
+      'ru': 'Видео',
+      'de': 'Video',
+      'fr': 'Vidéo',
+      'es': 'Video',
+      'zh': '视频',
+    },
+    'startCallAction': {
+      'en': 'Start call',
+      'ru': 'Начать звонок',
+      'de': 'Anruf starten',
+      'fr': 'Démarrer l’appel',
+      'es': 'Iniciar llamada',
+      'zh': '开始通话',
+    },
+    'callScreenTitle': {
+      'en': '{type} call',
+      'ru': '{type} звонок',
+      'de': '{type}-Anruf',
+      'fr': 'Appel {type}',
+      'es': 'Llamada {type}',
+      'zh': '{type}通话',
+    },
+    'callingLabel': {
+      'en': 'Calling: {names}',
+      'ru': 'Звонок: {names}',
+      'de': 'Rufe an: {names}',
+      'fr': 'Appel en cours : {names}',
+      'es': 'Llamando a: {names}',
+      'zh': '正在呼叫：{names}',
+    },
+    'callInProgress': {
+      'en': 'Call in progress',
+      'ru': 'Звонок в процессе',
+      'de': 'Anruf läuft',
+      'fr': 'Appel en cours',
+      'es': 'Llamada en curso',
+      'zh': '通话进行中',
+    },
+    'endCallAction': {
+      'en': 'End call',
+      'ru': 'Завершить звонок',
+      'de': 'Anruf beenden',
+      'fr': 'Terminer l’appel',
+      'es': 'Finalizar llamada',
+      'zh': '结束通话',
+    },
+    'upcomingEventsTitle': {
+      'en': 'Upcoming events',
+      'ru': 'Предстоящие события',
+      'de': 'Bevorstehende Ereignisse',
+      'fr': 'Événements à venir',
+      'es': 'Próximos eventos',
+      'zh': '即将到来的活动',
+    },
+    'aiSuggestionsMembersChip': {
+      'en': 'Members: {count}',
+      'ru': 'Участники: {count}',
+      'de': 'Mitglieder: {count}',
+      'fr': 'Membres : {count}',
+      'es': 'Miembros: {count}',
+      'zh': '成员：{count}',
+    },
+    'aiSuggestionsTasksChip': {
+      'en': 'Tasks: {count}',
+      'ru': 'Задачи: {count}',
+      'de': 'Aufgaben: {count}',
+      'fr': 'Tâches : {count}',
+      'es': 'Tareas: {count}',
+      'zh': '任务：{count}',
+    },
+    'aiSuggestionsNextEventChip': {
+      'en': 'Next event: {title}',
+      'ru': 'Следующее событие: {title}',
+      'de': 'Nächstes Ereignis: {title}',
+      'fr': 'Prochain événement : {title}',
+      'es': 'Próximo evento: {title}',
+      'zh': '下一个活动：{title}',
+    },
+    'aiSuggestionsContextHeader': {
+      'en': 'Here is your family context:',
+      'ru': 'Вот контекст вашей семьи:',
+      'de': 'Hier ist der Familienkontext:',
+      'fr': 'Voici le contexte de votre famille :',
+      'es': 'Este es el contexto de su familia:',
+      'zh': '以下是您的家庭情况：',
+    },
+    'aiSuggestionsContextMembers': {
+      'en': 'Members in the family: {count}',
+      'ru': 'Участников в семье: {count}',
+      'de': 'Mitglieder in der Familie: {count}',
+      'fr': 'Membres dans la famille : {count}',
+      'es': 'Miembros en la familia: {count}',
+      'zh': '家庭成员数：{count}',
+    },
+    'aiSuggestionsContextTasks': {
+      'en': 'Open tasks: {count}',
+      'ru': 'Открытых задач: {count}',
+      'de': 'Offene Aufgaben: {count}',
+      'fr': 'Tâches ouvertes : {count}',
+      'es': 'Tareas abiertas: {count}',
+      'zh': '未完成任务：{count}',
+    },
+    'aiSuggestionsContextNextEvent': {
+      'en': 'Next event "{title}" on {date}',
+      'ru': 'Следующее событие «{title}» {date}',
+      'de': 'Nächstes Ereignis „{title}“ am {date}',
+      'fr': 'Prochain événement « {title} » le {date}',
+      'es': 'Próximo evento "{title}" el {date}',
+      'zh': '下一个活动“{title}”时间：{date}',
+    },
+    'aiSuggestionsDefaultPrompt': {
+      'en': 'Suggest helpful family ideas',
+      'ru': 'Предложи полезные семейные идеи',
+      'de': 'Schlage hilfreiche Familienideen vor',
+      'fr': 'Suggère des idées utiles pour la famille',
+      'es': 'Sugiere ideas útiles para la familia',
+      'zh': '提供有用的家庭建议',
+    },
+    'aiSuggestionsPromptHint': {
+      'en': 'Describe what you need help with…',
+      'ru': 'Опишите, чем нужна помощь…',
+      'de': 'Beschreiben Sie, wobei Sie Hilfe brauchen …',
+      'fr': 'Décrivez ce dont vous avez besoin…',
+      'es': 'Describa en qué necesita ayuda…',
+      'zh': '描述需要帮助的内容…',
+    },
+    'aiSuggestionsEmptyState': {
+      'en': 'Ask the assistant for activity ideas, meal plans, or reminders.',
+      'ru': 'Попросите помощника идеи для занятий, план питания или напоминания.',
+      'de': 'Fragen Sie den Assistenten nach Aktivitäten, Essensplänen oder Erinnerungen.',
+      'fr': 'Demandez à l’assistant des idées d’activités, des menus ou des rappels.',
+      'es': 'Pida al asistente ideas de actividades, menús o recordatorios.',
+      'zh': '请向助手寻求活动灵感、菜单或提醒。',
+    },
+    'aiSuggestionsError': {
+      'en': 'Could not load suggestions: {error}',
+      'ru': 'Не удалось получить подсказки: {error}',
+      'de': 'Vorschläge konnten nicht geladen werden: {error}',
+      'fr': 'Impossible de charger les suggestions : {error}',
+      'es': 'No se pudieron cargar las sugerencias: {error}',
+      'zh': '无法加载建议：{error}',
+    },
+    'editMember': {
+      'en': 'Edit member',
+      'ru': 'Редактировать участника',
+      'de': 'Mitglied bearbeiten',
+      'fr': 'Modifier le membre',
+      'es': 'Editar miembro',
+      'zh': '编辑成员',
+    },
+    'deleteMemberDialogTitle': {
+      'en': 'Delete member',
+      'ru': 'Удалить участника',
+      'de': 'Mitglied löschen',
+      'fr': 'Supprimer le membre',
+      'es': 'Eliminar miembro',
+      'zh': '删除成员',
+    },
+    'confirmRemoveMember': {
+      'en': 'Remove {name}?',
+      'ru': 'Удалить {name}?',
+      'de': '{name} entfernen?',
+      'fr': 'Supprimer {name} ?',
+      'es': '¿Eliminar a {name}?',
+      'zh': '删除{name}？',
+    },
+    'clearAction': {
+      'en': 'Clear',
+      'ru': 'Очистить',
+      'de': 'Leeren',
+      'fr': 'Effacer',
+      'es': 'Limpiar',
+      'zh': '清除',
+    },
+    'generateAction': {
+      'en': 'Generate',
+      'ru': 'Сгенерировать',
+      'de': 'Generieren',
+      'fr': 'Générer',
+      'es': 'Generar',
+      'zh': '生成',
+    },
+    'locationLabel': {
+      'en': 'Location',
+      'ru': 'Место',
+      'de': 'Ort',
+      'fr': 'Lieu',
+      'es': 'Ubicación',
+      'zh': '地点',
+    },
+    'memberHobbiesTitle': {
+      'en': 'Hobbies – {name}',
+      'ru': 'Увлечения — {name}',
+      'de': 'Hobbys – {name}',
+      'fr': 'Loisirs – {name}',
+      'es': 'Aficiones – {name}',
+      'zh': '爱好 – {name}',
+    },
+    'noHobbiesLabel': {
+      'en': 'No hobbies yet',
+      'ru': 'Увлечений пока нет',
+      'de': 'Noch keine Hobbys',
+      'fr': 'Aucun loisir pour le moment',
+      'es': 'Aún no hay aficiones',
+      'zh': '暂无爱好',
     },
   };
 
-  String t(String key, {Map<String, String>? params}) {
-    final languageCode = locale.languageCode;
-    final template = _localizedValues[languageCode]?[key] ??
-        _localizedValues['en']?[key] ??
-        key;
-    if (params == null || params.isEmpty) {
-      return template;
+
+  /// Returns the translation for [key] or the key itself if the translation
+  /// is missing.  This fallback ensures the UI remains functional even when
+  /// a string is not yet translated.
+  String translate(String key) {
+    final Map<String, String>? values = _localizedValues[key];
+    if (values != null) {
+      return values[locale.languageCode] ?? values['en'] ?? key;
     }
-    var result = template;
-    params.forEach((placeholder, value) {
-      result = result.replaceAll('{$placeholder}', value);
+    return key;
+  }
+
+  /// Looks up the translation for [key] and replaces placeholders of the form
+  /// `{placeholder}` with the values provided in [params].
+  String translateWithParams(String key, Map<String, String> params) {
+    String value = translate(key);
+    params.forEach((String placeholder, String replacement) {
+      value = value.replaceAll('{$placeholder}', replacement);
     });
-    return result;
+    return value;
+  }
+
+  String t(String key, {Map<String, String>? params}) {
+    if (params == null || params.isEmpty) {
+      return translate(key);
+    }
+    return translateWithParams(key, params);
   }
 
   String languageName(String code) {
     switch (code) {
       case 'ru':
-        return t('languageRussian');
+        return translate('languageRussian');
+      case 'de':
+        return translate('languageGerman');
+      case 'fr':
+        return translate('languageFrench');
+      case 'es':
+        return translate('languageSpanish');
+      case 'zh':
+        return translate('languageChinese');
       case 'en':
       default:
-        return t('languageEnglish');
+        return translate('languageEnglish');
     }
   }
+
+  /// Formats a date respecting the current locale.
+  String formatDate(DateTime date, {bool withTime = false}) {
+    final DateFormat format = withTime
+        ? DateFormat.yMd(localeName).add_Hm()
+        : DateFormat.yMd(localeName);
+    return format.format(date);
+  }
+
+  /// Formats a date range (start → end).
+  String formatDateRange(DateTime start, DateTime end) {
+    final DateFormat dateFormat = DateFormat.yMd(localeName).add_Hm();
+    return '${dateFormat.format(start)} → ${dateFormat.format(end)}';
+  }
+
+  /// Convenience helpers for common dynamic messages.
+  String confirmDelete(String title) => translateWithParams(
+        'confirmDelete',
+        {'item': title},
+      );
+
+  String confirmRemoveMember(String name) => translateWithParams(
+        'confirmRemoveMember',
+        {'name': name.isEmpty ? translate('memberFallback') : name},
+      );
+
+  String birthdayLabel(DateTime date) =>
+      translateWithParams('birthdayWithDate', {'date': formatDate(date)});
 }
 
 class _AppLocalizationsDelegate
@@ -135,18 +1873,32 @@ class _AppLocalizationsDelegate
   @override
   bool isSupported(Locale locale) {
     return AppLocalizations.supportedLocales
-        .any((supportedLocale) => supportedLocale.languageCode == locale.languageCode);
+        .map((Locale loc) => loc.languageCode)
+        .contains(locale.languageCode);
   }
 
   @override
-  Future<AppLocalizations> load(Locale locale) async {
-    return AppLocalizations(locale);
+  Future<AppLocalizations> load(Locale locale) {
+    return AppLocalizations.load(locale);
   }
 
   @override
-  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) => false;
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) =>
+      false;
 }
 
 extension AppLocalizationExtension on BuildContext {
+  /// Short-hand to get the current [AppLocalizations] instance.
+  AppLocalizations get loc => AppLocalizations.of(this);
+
+  /// Backwards compatibility getter used in older code.
   AppLocalizations get l10n => AppLocalizations.of(this);
+
+  /// Translates [key] using [AppLocalizations.translate].
+  String tr(String key) => loc.translate(key);
+
+  /// Translates [key] using parameters.
+  String trParams(String key, Map<String, String> params) =>
+      loc.translateWithParams(key, params);
 }
+

--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -1,7 +1,10 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
+import 'config/app_config.dart';
+import 'firebase_options.dart';
 import 'l10n/app_localizations.dart';
 import 'providers/chat_provider.dart';
 import 'providers/family_data.dart';
@@ -10,57 +13,100 @@ import 'providers/gallery_data.dart';
 import 'providers/language_provider.dart';
 import 'providers/schedule_data.dart';
 import 'screens/home_screen.dart';
+import 'services/firestore_service.dart';
+import 'services/storage_service.dart';
+import 'storage/hive_secure.dart';
 
-/// Entry point for the Family App. The root widget wires up all
-/// providers so the different feature screens can access shared state.
+/// Entry point for the Family App. Initializes Firebase, Hive and all
+/// services required by the application.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   await Hive.initFlutter();
+  await HiveSecure.ensureDek();
   final settingsBox = await Hive.openBox('settings');
-  final chatProvider = ChatProvider();
-  await chatProvider.init();
+
+  final firestore = FirestoreService();
+  final storage = StorageService();
   final languageProvider = LanguageProvider(box: settingsBox);
+
   runApp(
     MyApp(
-      chatProvider: chatProvider,
+      firestore: firestore,
+      storage: storage,
       languageProvider: languageProvider,
     ),
   );
 }
 
 class MyApp extends StatelessWidget {
-  final ChatProvider chatProvider;
-  final LanguageProvider languageProvider;
-
   const MyApp({
     super.key,
-    required this.chatProvider,
+    required this.firestore,
+    required this.storage,
     required this.languageProvider,
   });
+
+  final FirestoreService firestore;
+  final StorageService storage;
+  final LanguageProvider languageProvider;
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider<ChatProvider>.value(value: chatProvider),
-        ChangeNotifierProvider<LanguageProvider>.value(value: languageProvider),
-        ChangeNotifierProvider(create: (_) => FamilyData()),
-        ChangeNotifierProvider(create: (_) => FriendsData()),
-        ChangeNotifierProvider(create: (_) => GalleryData()),
-        ChangeNotifierProvider(create: (_) => ScheduleData()),
+        Provider<FirestoreService>.value(value: firestore),
+        Provider<StorageService>.value(value: storage),
+        ChangeNotifierProvider<LanguageProvider>.value(
+          value: languageProvider,
+        ),
+        ChangeNotifierProvider<ChatProvider>(
+          create: (_) => ChatProvider(
+            firestore: firestore,
+            storage: storage,
+            familyId: AppConfig.familyId,
+          )..init(),
+        ),
+        ChangeNotifierProvider<FamilyData>(
+          create: (_) => FamilyData(
+            firestore: firestore,
+            familyId: AppConfig.familyId,
+          )..load(),
+        ),
+        ChangeNotifierProvider<FriendsData>(
+          create: (_) => FriendsData(
+            firestore: firestore,
+            familyId: AppConfig.familyId,
+          )..load(),
+        ),
+        ChangeNotifierProvider<GalleryData>(
+          create: (_) => GalleryData(
+            firestore: firestore,
+            storage: storage,
+            familyId: AppConfig.familyId,
+          )..load(),
+        ),
+        ChangeNotifierProvider<ScheduleData>(
+          create: (_) => ScheduleData(
+            firestore: firestore,
+            familyId: AppConfig.familyId,
+          )..load(),
+        ),
       ],
       child: Consumer<LanguageProvider>(
         builder: (context, language, _) {
           return MaterialApp(
             debugShowCheckedModeBanner: false,
-            onGenerateTitle: (context) => context.l10n.t('appTitle'),
-            locale: language.locale,
-            supportedLocales: AppLocalizations.supportedLocales,
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
             theme: ThemeData(
               colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
               useMaterial3: true,
             ),
+            locale: language.locale,
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            onGenerateTitle: (context) => context.tr('appTitle'),
             home: const HomeScreen(),
           );
         },

--- a/FamilyAppFlutter/lib/models/chat.dart
+++ b/FamilyAppFlutter/lib/models/chat.dart
@@ -18,7 +18,7 @@ class Chat extends HiveObject {
 
   /// List of member identifiers participating in this chat.
   @HiveField(2)
-  List<dynamic> memberIds;
+  List<String> memberIds;
 
   /// Timestamp of the last activity in this chat.
   @HiveField(3)
@@ -35,4 +35,25 @@ class Chat extends HiveObject {
     required this.updatedAt,
     this.lastMessagePreview,
   });
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'title': title,
+        'memberIds': memberIds,
+        'updatedAt': updatedAt.toIso8601String(),
+        'lastMessagePreview': lastMessagePreview,
+      };
+
+  static Chat fromMap(Map<String, dynamic> map) => Chat(
+        id: (map['id'] ?? '').toString(),
+        title: (map['title'] ?? '').toString(),
+        memberIds: (map['memberIds'] as List?)
+                ?.map((dynamic e) => e.toString())
+                .toList() ??
+            <String>[],
+        updatedAt: map['updatedAt'] is String
+            ? DateTime.tryParse(map['updatedAt']) ?? DateTime.now()
+            : DateTime.now(),
+        lastMessagePreview: map['lastMessagePreview'] as String?,
+      );
 }

--- a/FamilyAppFlutter/lib/models/chat.g.dart
+++ b/FamilyAppFlutter/lib/models/chat.g.dart
@@ -22,7 +22,7 @@ class ChatAdapter extends TypeAdapter<Chat> {
     return Chat(
       id: fields[0] as String,
       title: fields[1] as String,
-      memberIds: (fields[2] as List).cast(),
+      memberIds: (fields[2] as List).cast<String>(),
       updatedAt: fields[3] as DateTime,
       lastMessagePreview: fields[4] as String?,
     );

--- a/FamilyAppFlutter/lib/models/chat_message.dart
+++ b/FamilyAppFlutter/lib/models/chat_message.dart
@@ -49,6 +49,10 @@ class ChatMessage extends HiveObject {
   @HiveField(6)
   bool isRead;
 
+  /// Optional storage path of the attachment (if any).
+  @HiveField(7)
+  String? storagePath;
+
   ChatMessage({
     required this.id,
     required this.chatId,
@@ -57,5 +61,44 @@ class ChatMessage extends HiveObject {
     required this.createdAt,
     required this.type,
     required this.isRead,
+    this.storagePath,
   });
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'chatId': chatId,
+        'senderId': senderId,
+        'content': content,
+        'createdAt': createdAt.toIso8601String(),
+        'type': type.name,
+        'isRead': isRead,
+        'storagePath': storagePath,
+      };
+
+  static ChatMessage fromMap(Map<String, dynamic> map) => ChatMessage(
+        id: (map['id'] ?? '').toString(),
+        chatId: (map['chatId'] ?? '').toString(),
+        senderId: (map['senderId'] ?? '').toString(),
+        content: (map['content'] ?? '').toString(),
+        createdAt: map['createdAt'] is String
+            ? DateTime.tryParse(map['createdAt']) ?? DateTime.now()
+            : DateTime.now(),
+        type: _messageTypeFromString(map['type']),
+        isRead: map['isRead'] is bool
+            ? map['isRead'] as bool
+            : (map['isRead']?.toString().toLowerCase() == 'true'),
+        storagePath: map['storagePath'] as String?,
+      );
+
+  static MessageType _messageTypeFromString(dynamic value) {
+    final name = value?.toString();
+    switch (name) {
+      case 'image':
+        return MessageType.image;
+      case 'file':
+        return MessageType.file;
+      default:
+        return MessageType.text;
+    }
+  }
 }

--- a/FamilyAppFlutter/lib/models/chat_message.g.dart
+++ b/FamilyAppFlutter/lib/models/chat_message.g.dart
@@ -53,13 +53,14 @@ class ChatMessageAdapter extends TypeAdapter<ChatMessage> {
       createdAt: fields[4] as DateTime,
       type: fields[5] as MessageType,
       isRead: fields[6] as bool,
+      storagePath: fields[7] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, ChatMessage obj) {
     writer
-      ..writeByte(7)
+      ..writeByte(8)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -73,6 +74,8 @@ class ChatMessageAdapter extends TypeAdapter<ChatMessage> {
       ..writeByte(5)
       ..write(obj.type)
       ..writeByte(6)
-      ..write(obj.isRead);
+      ..write(obj.isRead)
+      ..writeByte(7)
+      ..write(obj.storagePath);
   }
 }

--- a/FamilyAppFlutter/lib/models/family_member.dart
+++ b/FamilyAppFlutter/lib/models/family_member.dart
@@ -8,6 +8,7 @@ class FamilyMember {
   final String? phone;
   final String? email;
   final String? avatarUrl;
+  final String? avatarStoragePath;
   final String? socialMedia;
   final String? hobbies;
   final String? documents;
@@ -23,6 +24,7 @@ class FamilyMember {
     this.phone,
     this.email,
     this.avatarUrl,
+    this.avatarStoragePath,
     this.socialMedia,
     this.hobbies,
     this.documents,
@@ -39,6 +41,7 @@ class FamilyMember {
         'phone': phone,
         'email': email,
         'avatarUrl': avatarUrl,
+        'avatarStoragePath': avatarStoragePath,
         'socialMedia': socialMedia,
         'hobbies': hobbies,
         'documents': documents,
@@ -57,6 +60,7 @@ class FamilyMember {
         phone: m['phone'] as String?,
         email: m['email'] as String?,
         avatarUrl: m['avatarUrl'] as String?,
+        avatarStoragePath: m['avatarStoragePath'] as String?,
         socialMedia: m['socialMedia'] as String?,
         hobbies: m['hobbies'] as String?,
         documents: m['documents'] as String?,
@@ -81,6 +85,7 @@ class FamilyMember {
     Object? phone = _sentinel,
     Object? email = _sentinel,
     Object? avatarUrl = _sentinel,
+    Object? avatarStoragePath = _sentinel,
     Object? socialMedia = _sentinel,
     Object? hobbies = _sentinel,
     Object? documents = _sentinel,
@@ -98,6 +103,9 @@ class FamilyMember {
       email: email == _sentinel ? this.email : email as String?,
       avatarUrl:
           avatarUrl == _sentinel ? this.avatarUrl : avatarUrl as String?,
+      avatarStoragePath: avatarStoragePath == _sentinel
+          ? this.avatarStoragePath
+          : avatarStoragePath as String?,
       socialMedia: socialMedia == _sentinel
           ? this.socialMedia
           : socialMedia as String?,

--- a/FamilyAppFlutter/lib/models/friend.dart
+++ b/FamilyAppFlutter/lib/models/friend.dart
@@ -9,4 +9,14 @@ class Friend {
   final String? name;
 
   Friend({this.id, this.name});
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'name': name,
+      };
+
+  static Friend fromMap(Map<String, dynamic> map) => Friend(
+        id: (map['id'] ?? '').toString(),
+        name: map['name'] as String?,
+      );
 }

--- a/FamilyAppFlutter/lib/models/gallery_item.dart
+++ b/FamilyAppFlutter/lib/models/gallery_item.dart
@@ -4,6 +4,19 @@
 class GalleryItem {
   final String? id;
   final String? url;
+  final String? storagePath;
 
-  GalleryItem({this.id, this.url});
+  GalleryItem({this.id, this.url, this.storagePath});
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'url': url,
+        'storagePath': storagePath,
+      };
+
+  static GalleryItem fromMap(Map<String, dynamic> map) => GalleryItem(
+        id: (map['id'] ?? '').toString(),
+        url: map['url'] as String?,
+        storagePath: map['storagePath'] as String?,
+      );
 }

--- a/FamilyAppFlutter/lib/providers/friends_data.dart
+++ b/FamilyAppFlutter/lib/providers/friends_data.dart
@@ -1,19 +1,47 @@
 import 'package:flutter/foundation.dart';
 
 import '../models/friend.dart';
+import '../services/firestore_service.dart';
 
-/// Provider for managing a list of friends.  This example is
-/// intentionally lightweight; methods could be expanded to include
-/// editing or deleting friends as needed.
+/// Provider for managing a list of friends stored remotely.
 class FriendsData extends ChangeNotifier {
+  FriendsData({required FirestoreService firestore, required this.familyId})
+      : _firestore = firestore;
+
+  final FirestoreService _firestore;
+  final String familyId;
+
   final List<Friend> friends = [];
 
-  void addFriend(Friend friend) {
+  bool _loaded = false;
+  bool _isLoading = false;
+
+  bool get isLoading => _isLoading;
+
+  Future<void> load() async {
+    if (_loaded || _isLoading) return;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final fetched = await _firestore.fetchFriends(familyId);
+      friends
+        ..clear()
+        ..addAll(fetched);
+      _loaded = true;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> addFriend(Friend friend) async {
+    await _firestore.upsertFriend(familyId, friend);
     friends.add(friend);
     notifyListeners();
   }
 
-  void removeFriend(String id) {
+  Future<void> removeFriend(String id) async {
+    await _firestore.deleteFriend(familyId, id);
     friends.removeWhere((friend) => friend.id == id);
     notifyListeners();
   }

--- a/FamilyAppFlutter/lib/providers/schedule_data.dart
+++ b/FamilyAppFlutter/lib/providers/schedule_data.dart
@@ -1,19 +1,47 @@
 import 'package:flutter/foundation.dart';
 
 import '../models/schedule_item.dart';
+import '../services/firestore_service.dart';
 
-/// Provider for managing schedule items.  Items can be added and
-/// listeners are notified of changes.  Additional methods for
-/// filtering or updating items could be added later.
+/// Provider for managing schedule items backed by Firestore.
 class ScheduleData extends ChangeNotifier {
+  ScheduleData({required FirestoreService firestore, required this.familyId})
+      : _firestore = firestore;
+
+  final FirestoreService _firestore;
+  final String familyId;
+
   final List<ScheduleItem> items = [];
 
-  void addItem(ScheduleItem item) {
+  bool _loaded = false;
+  bool _isLoading = false;
+
+  bool get isLoading => _isLoading;
+
+  Future<void> load() async {
+    if (_loaded || _isLoading) return;
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final fetched = await _firestore.fetchScheduleItems(familyId);
+      items
+        ..clear()
+        ..addAll(fetched);
+      _loaded = true;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> addItem(ScheduleItem item) async {
+    await _firestore.upsertScheduleItem(familyId, item);
     items.add(item);
     notifyListeners();
   }
 
-  void removeItem(String id) {
+  Future<void> removeItem(String id) async {
+    await _firestore.deleteScheduleItem(familyId, id);
     items.removeWhere((item) => item.id == id);
     notifyListeners();
   }

--- a/FamilyAppFlutter/lib/screens/add_chat_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_chat_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/family_member.dart';
 import '../providers/chat_provider.dart';
 import '../providers/family_data.dart';
@@ -28,7 +29,7 @@ class _AddChatScreenState extends State<AddChatScreen> {
     if (form == null || !form.validate()) return;
     if (_selectedMemberIds.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Select at least one participant.')),
+        SnackBar(content: Text(context.tr('selectParticipantsError'))),
       );
       return;
     }
@@ -46,7 +47,7 @@ class _AddChatScreenState extends State<AddChatScreen> {
   Widget build(BuildContext context) {
     final members = context.watch<FamilyData>().members;
     return Scaffold(
-      appBar: AppBar(title: const Text('Create chat')),
+      appBar: AppBar(title: Text(context.tr('createChatTitle'))),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(
@@ -56,19 +57,20 @@ class _AddChatScreenState extends State<AddChatScreen> {
             children: [
               TextFormField(
                 controller: _titleController,
-                decoration: const InputDecoration(labelText: 'Chat title'),
+                decoration: InputDecoration(labelText: context.tr('chatTitleLabel')),
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
-                    return 'Please enter a title';
+                    return context.tr('chatTitleValidation');
                   }
                   return null;
                 },
               ),
               const SizedBox(height: 16),
-              Text('Participants', style: Theme.of(context).textTheme.titleMedium),
+              Text(context.tr('participantsLabel'),
+                  style: Theme.of(context).textTheme.titleMedium),
               const SizedBox(height: 8),
               if (members.isEmpty)
-                const Text('Add family members first to create a chat.')
+                Text(context.tr('noMembersForChat'))
               else
                 Wrap(
                   spacing: 8,
@@ -76,7 +78,7 @@ class _AddChatScreenState extends State<AddChatScreen> {
                   children: [
                     for (final FamilyMember member in members)
                       FilterChip(
-                        label: Text(member.name ?? 'Unnamed'),
+                        label: Text(member.name ?? context.tr('noNameLabel')),
                         selected: _selectedMemberIds.contains(member.id),
                         onSelected: (selected) {
                           setState(() {
@@ -96,7 +98,7 @@ class _AddChatScreenState extends State<AddChatScreen> {
                 child: FilledButton.icon(
                   onPressed: _save,
                   icon: const Icon(Icons.save),
-                  label: const Text('Create chat'),
+                  label: Text(context.tr('createChatAction')),
                 ),
               ),
             ],

--- a/FamilyAppFlutter/lib/screens/add_event_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_event_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/event.dart';
 import '../models/family_member.dart';
 import '../providers/family_data.dart';
@@ -88,7 +88,7 @@ class _AddEventScreenState extends State<AddEventScreen> {
     });
   }
 
-  void _save() {
+  Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
 
@@ -108,15 +108,17 @@ class _AddEventScreenState extends State<AddEventScreen> {
       participantIds: _participantIds.toList(),
     );
 
-    context.read<FamilyData>().addEvent(event);
-    Navigator.of(context).pop();
+    await context.read<FamilyData>().addEvent(event);
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final members = context.watch<FamilyData>().members;
     return Scaffold(
-      appBar: AppBar(title: const Text('Add Event')),
+      appBar: AppBar(title: Text(context.tr('addEventTitle'))),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: SingleChildScrollView(
@@ -127,10 +129,10 @@ class _AddEventScreenState extends State<AddEventScreen> {
               children: [
                 TextFormField(
                   controller: _titleController,
-                  decoration: const InputDecoration(labelText: 'Title'),
+                  decoration: InputDecoration(labelText: context.tr('eventTitleLabel')),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
-                      return 'Please enter a title';
+                      return context.tr('validationEnterTitle');
                     }
                     return null;
                   },
@@ -138,7 +140,8 @@ class _AddEventScreenState extends State<AddEventScreen> {
                 const SizedBox(height: 12),
                 TextFormField(
                   controller: _descriptionController,
-                  decoration: const InputDecoration(labelText: 'Description'),
+                  decoration:
+                      InputDecoration(labelText: context.tr('eventDescriptionLabel')),
                   maxLines: 3,
                 ),
                 const SizedBox(height: 20),
@@ -149,8 +152,8 @@ class _AddEventScreenState extends State<AddEventScreen> {
                         onPressed: _pickStartDate,
                         child: Text(
                           _startDate == null
-                              ? 'Select start'
-                              : 'Start: ${_formatDate(_startDate!)}',
+                              ? context.tr('selectStartLabel')
+                              : context.loc.formatDate(_startDate!, withTime: true),
                         ),
                       ),
                     ),
@@ -160,18 +163,19 @@ class _AddEventScreenState extends State<AddEventScreen> {
                         onPressed: _pickEndDate,
                         child: Text(
                           _endDate == null
-                              ? 'Select end'
-                              : 'End: ${_formatDate(_endDate!)}',
+                              ? context.tr('selectEndLabel')
+                              : context.loc.formatDate(_endDate!, withTime: true),
                         ),
                       ),
                     ),
                   ],
                 ),
                 const SizedBox(height: 20),
-                Text('Participants', style: Theme.of(context).textTheme.titleMedium),
+                Text(context.tr('participantsLabel'),
+                    style: Theme.of(context).textTheme.titleMedium),
                 const SizedBox(height: 8),
                 if (members.isEmpty)
-                  const Text('Add family members to assign participants.')
+                  Text(context.tr('noMembersForParticipants'))
                 else
                   Wrap(
                     spacing: 8,
@@ -179,7 +183,7 @@ class _AddEventScreenState extends State<AddEventScreen> {
                     children: [
                       for (final FamilyMember member in members)
                         FilterChip(
-                          label: Text(member.name ?? 'Unnamed'),
+                          label: Text(member.name ?? context.tr('noNameLabel')),
                           selected: _participantIds.contains(member.id),
                           onSelected: (selected) {
                             setState(() {
@@ -199,7 +203,7 @@ class _AddEventScreenState extends State<AddEventScreen> {
                   child: FilledButton.icon(
                     onPressed: _save,
                     icon: const Icon(Icons.save),
-                    label: const Text('Save event'),
+                    label: Text(context.tr('saveEventAction')),
                   ),
                 ),
               ],
@@ -209,6 +213,4 @@ class _AddEventScreenState extends State<AddEventScreen> {
       ),
     );
   }
-
-  String _formatDate(DateTime date) => DateFormat('dd.MM.yyyy HH:mm').format(date);
 }

--- a/FamilyAppFlutter/lib/screens/add_friend_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_friend_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/friend.dart';
 import '../providers/friends_data.dart';
 
@@ -23,21 +24,21 @@ class _AddFriendScreenState extends State<AddFriendScreen> {
     super.dispose();
   }
 
-  void _save() {
+  Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
     final friend = Friend(
       id: _uuid.v4(),
       name: _nameController.text.trim(),
     );
-    context.read<FriendsData>().addFriend(friend);
+    await context.read<FriendsData>().addFriend(friend);
     Navigator.of(context).pop();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Add friend')),
+      appBar: AppBar(title: Text(context.tr('addFriendTitle'))),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(
@@ -46,10 +47,10 @@ class _AddFriendScreenState extends State<AddFriendScreen> {
             children: [
               TextFormField(
                 controller: _nameController,
-                decoration: const InputDecoration(labelText: 'Name'),
+                decoration: InputDecoration(labelText: context.tr('fieldName')),
                 validator: (value) {
                   if (value == null || value.trim().isEmpty) {
-                    return 'Please enter a name';
+                    return context.tr('validationEnterName');
                   }
                   return null;
                 },
@@ -60,7 +61,7 @@ class _AddFriendScreenState extends State<AddFriendScreen> {
                 child: FilledButton.icon(
                   onPressed: _save,
                   icon: const Icon(Icons.save),
-                  label: const Text('Save'),
+                  label: Text(context.tr('saveAction')),
                 ),
               ),
             ],

--- a/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
@@ -1,9 +1,14 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/gallery_item.dart';
 import '../providers/gallery_data.dart';
+import '../services/storage_service.dart';
 
 class AddGalleryItemScreen extends StatefulWidget {
   const AddGalleryItemScreen({super.key});
@@ -13,64 +18,103 @@ class AddGalleryItemScreen extends StatefulWidget {
 }
 
 class _AddGalleryItemScreenState extends State<AddGalleryItemScreen> {
-  final _formKey = GlobalKey<FormState>();
-  final _urlController = TextEditingController();
   final _uuid = const Uuid();
+  String? _downloadUrl;
+  String? _storagePath;
+  String? _fileName;
+  bool _uploading = false;
 
   @override
   void dispose() {
-    _urlController.dispose();
     super.dispose();
   }
 
-  void _save() {
-    final form = _formKey.currentState;
-    if (form == null || !form.validate()) return;
+  Future<void> _pickFile() async {
+    final storage = context.read<StorageService>();
+    final result = await FilePicker.platform.pickFiles(type: FileType.image);
+    if (result == null || result.files.isEmpty) return;
+    final path = result.files.single.path;
+    if (path == null) return;
+    setState(() {
+      _uploading = true;
+    });
+    final file = File(path);
+    try {
+      final upload = await storage.uploadGalleryItem(
+        familyId: context.read<GalleryData>().familyId,
+        file: file,
+      );
+      setState(() {
+        _downloadUrl = upload.downloadUrl;
+        _storagePath = upload.storagePath;
+        _fileName = result.files.single.name;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _uploading = false;
+        });
+      }
+    }
+  }
 
-    final url = _urlController.text.trim();
+  Future<void> _save() async {
+    if (_downloadUrl == null || _storagePath == null) return;
     final item = GalleryItem(
       id: _uuid.v4(),
-      url: url,
+      url: _downloadUrl,
+      storagePath: _storagePath,
     );
-    context.read<GalleryData>().addItem(item);
+    await context.read<GalleryData>().addItem(item);
     Navigator.of(context).pop();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Add gallery item')),
+      appBar: AppBar(title: Text(context.tr('addGalleryItemTitle'))),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            children: [
-              TextFormField(
-                controller: _urlController,
-                decoration: const InputDecoration(
-                  labelText: 'Image URL',
-                  hintText: 'https://example.com/photo.jpg',
-                ),
-                keyboardType: TextInputType.url,
-                validator: (value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return 'Please enter a URL';
-                  }
-                  return null;
-                },
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: _downloadUrl != null
+                  ? ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Image.network(
+                        _downloadUrl!,
+                        width: 64,
+                        height: 64,
+                        fit: BoxFit.cover,
+                      ),
+                    )
+                  : const Icon(Icons.photo),
+              title: Text(
+                _fileName ?? context.tr('galleryNoFileSelected'),
               ),
-              const SizedBox(height: 24),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: _save,
-                  icon: const Icon(Icons.save),
-                  label: const Text('Save'),
-                ),
+              subtitle: _uploading
+                  ? Text(context.tr('uploadingLabel'))
+                  : (_downloadUrl != null
+                      ? Text(context.tr('fileReadyLabel'))
+                      : null),
+              trailing: FilledButton.icon(
+                onPressed: _uploading ? null : _pickFile,
+                icon: const Icon(Icons.upload),
+                label: Text(context.tr('selectMediaButton')),
               ),
-            ],
-          ),
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _downloadUrl == null ? null : _save,
+                icon: const Icon(Icons.save),
+                label: Text(context.tr('saveAction')),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/family_member.dart';
 import '../models/schedule_item.dart';
 import '../providers/family_data.dart';
@@ -48,8 +48,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
       firstDate: DateTime(now.year - 1),
       lastDate: DateTime(now.year + 5),
     );
-    if (!mounted) return;
-    if (date == null) return;
+    if (!mounted || date == null) return;
     final time = await showTimePicker(
       context: context,
       initialTime: TimeOfDay.fromDateTime(initial),
@@ -66,7 +65,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
     });
   }
 
-  void _save() {
+  Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
 
@@ -85,15 +84,17 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
       memberId: _memberId,
     );
 
-    context.read<ScheduleData>().addItem(item);
-    Navigator.of(context).pop();
+    await context.read<ScheduleData>().addItem(item);
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final members = context.watch<FamilyData>().members;
     return Scaffold(
-      appBar: AppBar(title: const Text('Add schedule item')),
+      appBar: AppBar(title: Text(context.tr('addScheduleItemTitle'))),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
@@ -104,10 +105,11 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
               children: [
                 TextFormField(
                   controller: _titleController,
-                  decoration: const InputDecoration(labelText: 'Title'),
+                  decoration:
+                      InputDecoration(labelText: context.tr('scheduleTitleLabel')),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
-                      return 'Please enter a title';
+                      return context.tr('validationEnterTitle');
                     }
                     return null;
                   },
@@ -115,11 +117,11 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 const SizedBox(height: 12),
                 ListTile(
                   contentPadding: EdgeInsets.zero,
-                  title: const Text('Date & time'),
+                  title: Text(context.tr('scheduleDateTimeLabel')),
                   subtitle: Text(
                     _dateTime == null
-                        ? 'Not set'
-                        : DateFormat('dd.MM.yyyy HH:mm').format(_dateTime!),
+                        ? context.tr('notSetLabel')
+                        : context.loc.formatDate(_dateTime!, withTime: true),
                   ),
                   trailing: IconButton(
                     icon: const Icon(Icons.schedule),
@@ -128,17 +130,23 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<Duration?>(
-                  initialValue: _duration,
-                  decoration: const InputDecoration(labelText: 'Duration'),
+                  value: _duration,
+                  decoration:
+                      InputDecoration(labelText: context.tr('scheduleDurationLabel')),
                   items: [
-                    const DropdownMenuItem<Duration?>(
+                    DropdownMenuItem<Duration?>(
                       value: null,
-                      child: Text('Not specified'),
+                      child: Text(context.tr('durationNotSpecified')),
                     ),
                     ..._durationOptions.map(
                       (duration) => DropdownMenuItem<Duration?>(
                         value: duration,
-                        child: Text('${duration.inMinutes} minutes'),
+                        child: Text(
+                          context.loc.translateWithParams(
+                            'scheduleDurationMinutes',
+                            {'minutes': duration.inMinutes.toString()},
+                          ),
+                        ),
                       ),
                     ),
                   ],
@@ -146,17 +154,17 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String?>(
-                  initialValue: _memberId,
-                  decoration: const InputDecoration(labelText: 'Assign to member'),
+                  value: _memberId,
+                  decoration: InputDecoration(labelText: context.tr('assignToLabel')),
                   items: [
-                    const DropdownMenuItem<String?>(
+                    DropdownMenuItem<String?>(
                       value: null,
-                      child: Text('No member'),
+                      child: Text(context.tr('noMemberOption')),
                     ),
                     ...members.map(
                       (FamilyMember member) => DropdownMenuItem<String?>(
                         value: member.id,
-                        child: Text(member.name ?? 'Unnamed'),
+                        child: Text(member.name ?? context.tr('noNameLabel')),
                       ),
                     ),
                   ],
@@ -165,12 +173,12 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 const SizedBox(height: 12),
                 TextFormField(
                   controller: _locationController,
-                  decoration: const InputDecoration(labelText: 'Location'),
+                  decoration: InputDecoration(labelText: context.tr('locationLabel')),
                 ),
                 const SizedBox(height: 12),
                 TextFormField(
                   controller: _notesController,
-                  decoration: const InputDecoration(labelText: 'Notes'),
+                  decoration: InputDecoration(labelText: context.tr('notesLabel')),
                   maxLines: 3,
                 ),
                 const SizedBox(height: 24),
@@ -179,7 +187,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                   child: FilledButton.icon(
                     onPressed: _save,
                     icon: const Icon(Icons.save),
-                    label: const Text('Save item'),
+                    label: Text(context.tr('saveScheduleItemAction')),
                   ),
                 ),
               ],

--- a/FamilyAppFlutter/lib/screens/add_task_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_task_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/task.dart';
 import '../providers/family_data.dart';
 
-/// Screen for adding a new task.  Users can provide title, description,
+/// Screen for adding a new task. Users can provide title, description,
 /// due date, assignee and status.
 class AddTaskScreen extends StatefulWidget {
   const AddTaskScreen({super.key});
@@ -33,8 +33,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
       firstDate: DateTime(now.year - 1),
       lastDate: DateTime(now.year + 5),
     );
-    if (!mounted) return;
-    if (date == null) return;
+    if (!mounted || date == null) return;
     final timeOfDay = await showTimePicker(
       context: context,
       initialTime: TimeOfDay.fromDateTime(_dueDate ?? now),
@@ -51,7 +50,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
     });
   }
 
-  void _save() {
+  Future<void> _save() async {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) {
       return;
@@ -70,8 +69,10 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
       points: pointsValue,
     );
 
-    context.read<FamilyData>().addTask(task);
-    Navigator.of(context).pop();
+    await context.read<FamilyData>().addTask(task);
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
   }
 
   @override
@@ -86,7 +87,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
   Widget build(BuildContext context) {
     final members = context.watch<FamilyData>().members;
     return Scaffold(
-      appBar: AppBar(title: const Text('Add Task')),
+      appBar: AppBar(title: Text(context.tr('addTaskTitle'))),
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
@@ -97,10 +98,10 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
               children: [
                 TextFormField(
                   controller: _titleController,
-                  decoration: const InputDecoration(labelText: 'Title'),
+                  decoration: InputDecoration(labelText: context.tr('taskTitleLabel')),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
-                      return 'Please enter a title';
+                      return context.tr('validationEnterTitle');
                     }
                     return null;
                   },
@@ -108,17 +109,17 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 const SizedBox(height: 12),
                 TextFormField(
                   controller: _descriptionController,
-                  decoration: const InputDecoration(labelText: 'Description'),
+                  decoration: InputDecoration(labelText: context.tr('taskDescriptionLabel')),
                   maxLines: 3,
                 ),
                 const SizedBox(height: 12),
                 ListTile(
                   contentPadding: EdgeInsets.zero,
-                  title: const Text('Due date'),
+                  title: Text(context.tr('taskDueDate')),
                   subtitle: Text(
                     _dueDate == null
-                        ? 'Not set'
-                        : DateFormat('dd.MM.yyyy HH:mm').format(_dueDate!),
+                        ? context.tr('dateNotSet')
+                        : context.loc.formatDate(_dueDate!, withTime: true),
                   ),
                   trailing: IconButton(
                     onPressed: _pickDueDate,
@@ -127,13 +128,13 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<TaskStatus>(
-                  initialValue: _status,
-                  decoration: const InputDecoration(labelText: 'Status'),
+                  value: _status,
+                  decoration: InputDecoration(labelText: context.tr('taskStatusLabel')),
                   items: TaskStatus.values
                       .map(
                         (status) => DropdownMenuItem(
                           value: status,
-                          child: Text(status.name),
+                          child: Text(context.tr('taskStatus.${status.name}')),
                         ),
                       )
                       .toList(),
@@ -145,17 +146,17 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String?>(
-                  initialValue: _assigneeId,
-                  decoration: const InputDecoration(labelText: 'Assign to'),
+                  value: _assigneeId,
+                  decoration: InputDecoration(labelText: context.tr('assignToLabel')),
                   items: [
                     const DropdownMenuItem<String?>(
                       value: null,
-                      child: Text('Unassigned'),
+                      child: Text('—'),
                     ),
                     ...members.map(
                       (member) => DropdownMenuItem<String?>(
                         value: member.id,
-                        child: Text(member.name ?? 'Unnamed'),
+                        child: Text(member.name ?? context.tr('noNameLabel')),
                       ),
                     ),
                   ],
@@ -164,9 +165,9 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 const SizedBox(height: 12),
                 TextFormField(
                   controller: _pointsController,
-                  decoration: const InputDecoration(
-                    labelText: 'Reward points',
-                    hintText: 'Optional integer value',
+                  decoration: InputDecoration(
+                    labelText: context.tr('rewardPointsLabel'),
+                    hintText: context.tr('rewardPointsHint'),
                   ),
                   keyboardType: TextInputType.number,
                 ),
@@ -176,7 +177,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                   child: FilledButton.icon(
                     onPressed: _save,
                     icon: const Icon(Icons.save),
-                    label: const Text('Save'),
+                    label: Text(context.tr('saveAction')),
                   ),
                 ),
               ],

--- a/FamilyAppFlutter/lib/screens/calendar_feed_screen.dart
+++ b/FamilyAppFlutter/lib/screens/calendar_feed_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
+
 /// Placeholder screen for a calendar feed.  This simplified view
 /// contains no data and simply informs the user that no feed is
 /// available.  Expand this screen to show recent events or
@@ -10,8 +12,8 @@ class CalendarFeedScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Calendar Feed')),
-      body: const Center(child: Text('No calendar feed available.')),
+      appBar: AppBar(title: Text(context.tr('calendarFeed'))),
+      body: Center(child: Text(context.tr('noCalendarFeedLabel'))),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/calendar_screen.dart
+++ b/FamilyAppFlutter/lib/screens/calendar_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/event.dart';
 import '../models/task.dart';
 import '../providers/family_data.dart';
@@ -14,16 +14,17 @@ class CalendarScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Calendar')),
+      appBar: AppBar(title: Text(context.tr('calendar'))),
       body: Consumer<FamilyData>(
         builder: (context, data, _) {
           final events = data.events.toList()
             ..sort((a, b) => a.startDateTime.compareTo(b.startDateTime));
           final tasks = data.tasks.toList()
-            ..sort((a, b) => (a.dueDate ?? DateTime.now()).compareTo(b.dueDate ?? DateTime.now()));
+            ..sort((a, b) => (a.dueDate ?? DateTime.now())
+                .compareTo(b.dueDate ?? DateTime.now()));
 
           if (events.isEmpty && tasks.isEmpty) {
-            return const Center(child: Text('No events or tasks'));
+            return Center(child: Text(context.tr('noCalendarItemsLabel')));
           }
 
           return ListView(
@@ -31,7 +32,7 @@ class CalendarScreen extends StatelessWidget {
             children: [
               if (events.isNotEmpty) ...[
                 Text(
-                  'Upcoming events',
+                  context.tr('upcomingEventsTitle'),
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
                 const SizedBox(height: 8),
@@ -44,7 +45,10 @@ class CalendarScreen extends StatelessWidget {
                       subtitle: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(_formatRange(event.startDateTime, event.endDateTime)),
+                          Text(
+                            context.loc
+                                .formatDateRange(event.startDateTime, event.endDateTime),
+                          ),
                           if (event.description?.isNotEmpty == true)
                             Padding(
                               padding: const EdgeInsets.only(top: 4),
@@ -58,7 +62,7 @@ class CalendarScreen extends StatelessWidget {
               if (tasks.isNotEmpty) ...[
                 const SizedBox(height: 16),
                 Text(
-                  'Tasks',
+                  context.tr('tasksSectionTitle'),
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
                 const SizedBox(height: 8),
@@ -74,8 +78,11 @@ class CalendarScreen extends StatelessWidget {
                       subtitle: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text('Status: ${task.status.name}'),
-                          Text('Due: ${_formatDate(task.dueDate)}'),
+                          Text(
+                            '${context.tr('statusLabel')}: ${context.tr('taskStatus.${task.status.name}')}'),
+                          Text(
+                            '${context.tr('dueLabel')}: ${_formatDate(context, task.dueDate)}',
+                          ),
                         ],
                       ),
                     ),
@@ -88,14 +95,9 @@ class CalendarScreen extends StatelessWidget {
     );
   }
 
-  String _formatRange(DateTime start, DateTime end) {
-    final formatter = DateFormat('dd.MM.yyyy HH:mm');
-    return '${formatter.format(start)} – ${formatter.format(end)}';
-  }
-
-  String _formatDate(DateTime? date) {
-    if (date == null) return 'No due date';
-    return DateFormat('dd.MM.yyyy HH:mm').format(date);
+  String _formatDate(BuildContext context, DateTime? date) {
+    if (date == null) return context.tr('noDueDate');
+    return context.loc.formatDate(date, withTime: true);
   }
 
   Color _statusColor(BuildContext context, TaskStatus status) {

--- a/FamilyAppFlutter/lib/screens/call_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/conversation.dart';
-import '../providers/family_data.dart';
 import '../models/family_member.dart';
+import '../providers/family_data.dart';
 
 /// Screen that displays an in-progress audio or video call.
 class CallScreen extends StatelessWidget {
@@ -22,31 +23,46 @@ class CallScreen extends StatelessWidget {
     final participants = conversation.memberIds
         .map((id) => familyData.members.firstWhere(
               (member) => member.id == id,
-              orElse: () => FamilyMember(id: '', name: 'Unknown'),
+              orElse: () => FamilyMember(
+                id: '',
+                name: context.tr('unknownMemberLabel'),
+              ),
             ))
         .toList();
 
-    final callTypeLabel =
-        callType.isNotEmpty ? '${callType[0].toUpperCase()}${callType.substring(1)}' : '';
+    final typeLabel =
+        callType == 'video' ? context.tr('videoLabel') : context.tr('audioLabel');
 
     return Scaffold(
-      appBar: AppBar(title: Text('$callTypeLabel Call')),
+      appBar: AppBar(
+        title: Text(
+          context.loc.translateWithParams('callScreenTitle', {'type': typeLabel}),
+        ),
+      ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text(
-              'Calling ${participants.map((m) => m.name).join(', ')}',
+              context.loc.translateWithParams(
+                'callingLabel',
+                {
+                  'names': participants.map((m) => m.name ?? '').join(', '),
+                },
+              ),
               style: const TextStyle(fontSize: 18),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 20),
-            const Text('Call in progress...', style: TextStyle(fontSize: 24)),
+            Text(
+              context.tr('callInProgress'),
+              style: const TextStyle(fontSize: 24),
+            ),
             const SizedBox(height: 40),
             ElevatedButton.icon(
               onPressed: () => Navigator.of(context).pop(),
               icon: const Icon(Icons.call_end),
-              label: const Text('End Call'),
+              label: Text(context.tr('endCallAction')),
               style: ElevatedButton.styleFrom(
                 foregroundColor: Colors.white,
                 backgroundColor: Colors.red,

--- a/FamilyAppFlutter/lib/screens/call_setup_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_setup_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/conversation.dart';
 import '../models/family_member.dart';
 import '../providers/family_data.dart';
@@ -14,9 +15,17 @@ class CallSetupScreen extends StatefulWidget {
 }
 
 class _CallSetupScreenState extends State<CallSetupScreen> {
-  final _titleController = TextEditingController(text: 'Family call');
+  final _titleController = TextEditingController();
   String _callType = 'audio';
   final Set<String> _selectedMemberIds = {};
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_titleController.text.isEmpty) {
+      _titleController.text = context.tr('callDefaultTitle');
+    }
+  }
 
   @override
   void dispose() {
@@ -30,12 +39,12 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
         : members.map((member) => member.id).toList();
     if (selected.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Select at least one participant.')),
+        SnackBar(content: Text(context.tr('selectParticipantsError'))),
       );
       return;
     }
     final title = _titleController.text.trim().isEmpty
-        ? 'Call'
+        ? context.tr('callFallbackTitle')
         : _titleController.text.trim();
     final conversation = Conversation(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
@@ -57,7 +66,7 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
   Widget build(BuildContext context) {
     final members = context.watch<FamilyData>().members;
     return Scaffold(
-      appBar: AppBar(title: const Text('Start a call')),
+      appBar: AppBar(title: Text(context.tr('startCall'))),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -65,15 +74,24 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
           children: [
             TextField(
               controller: _titleController,
-              decoration: const InputDecoration(labelText: 'Call title'),
+              decoration: InputDecoration(labelText: context.tr('callTitleLabel')),
             ),
             const SizedBox(height: 16),
-            Text('Call type', style: Theme.of(context).textTheme.titleMedium),
+            Text(context.tr('callTypeLabel'),
+                style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             SegmentedButton<String>(
-              segments: const [
-                ButtonSegment(value: 'audio', label: Text('Audio'), icon: Icon(Icons.call)),
-                ButtonSegment(value: 'video', label: Text('Video'), icon: Icon(Icons.videocam)),
+              segments: [
+                ButtonSegment(
+                  value: 'audio',
+                  label: Text(context.tr('audioLabel')),
+                  icon: const Icon(Icons.call),
+                ),
+                ButtonSegment(
+                  value: 'video',
+                  label: Text(context.tr('videoLabel')),
+                  icon: const Icon(Icons.videocam),
+                ),
               ],
               selected: <String>{_callType},
               onSelectionChanged: (selection) {
@@ -81,10 +99,11 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
               },
             ),
             const SizedBox(height: 24),
-            Text('Participants', style: Theme.of(context).textTheme.titleMedium),
+            Text(context.tr('participantsLabel'),
+                style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             if (members.isEmpty)
-              const Text('Add family members to start a call.')
+              Text(context.tr('noMembersForCall'))
             else
               Wrap(
                 spacing: 8,
@@ -92,7 +111,7 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
                 children: [
                   for (final member in members)
                     FilterChip(
-                      label: Text(member.name ?? 'Unnamed'),
+                      label: Text(member.name ?? context.tr('noNameLabel')),
                       selected: _selectedMemberIds.contains(member.id),
                       onSelected: (selected) {
                         setState(() {
@@ -112,7 +131,7 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
               child: FilledButton.icon(
                 onPressed: () => _startCall(members),
                 icon: const Icon(Icons.play_arrow),
-                label: const Text('Start call'),
+                label: Text(context.tr('startCallAction')),
               ),
             ),
           ],

--- a/FamilyAppFlutter/lib/screens/chat_screen.dart
+++ b/FamilyAppFlutter/lib/screens/chat_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/chat.dart';
 import '../models/chat_message.dart';
 import '../providers/chat_provider.dart';
@@ -71,7 +71,7 @@ class _ChatScreenState extends State<ChatScreen> {
             children: [
               Expanded(
                 child: messages.isEmpty
-                    ? const Center(child: Text('No messages yet.'))
+                    ? Center(child: Text(context.tr('noMessagesLabel')))
                     : ListView.separated(
                         padding: const EdgeInsets.all(16),
                         itemCount: messages.length,
@@ -79,7 +79,8 @@ class _ChatScreenState extends State<ChatScreen> {
                         itemBuilder: (context, index) {
                           final ChatMessage message = messages[index];
                           final senderName =
-                              familyData.memberById(message.senderId)?.name ?? 'Unknown';
+                              familyData.memberById(message.senderId)?.name ??
+                                  context.tr('unknownMemberLabel');
                           return Align(
                             alignment: Alignment.centerLeft,
                             child: Container(
@@ -88,7 +89,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                 color: Theme.of(context)
                                     .colorScheme
                                     .primary
-                                    .withValues(alpha: 0.1),
+                                    .withOpacity(0.1),
                                 borderRadius: BorderRadius.circular(12),
                               ),
                               child: Column(
@@ -102,7 +103,10 @@ class _ChatScreenState extends State<ChatScreen> {
                                   Text(message.content),
                                   const SizedBox(height: 4),
                                   Text(
-                                    DateFormat('dd.MM.yyyy HH:mm').format(message.createdAt),
+                                    context.loc.formatDate(
+                                      message.createdAt,
+                                      withTime: true,
+                                    ),
                                     style: Theme.of(context)
                                         .textTheme
                                         .labelSmall
@@ -121,12 +125,12 @@ class _ChatScreenState extends State<ChatScreen> {
                   children: [
                     DropdownButton<String>(
                       value: _selectedSenderId,
-                      hint: const Text('Sender'),
+                      hint: Text(context.tr('senderLabel')),
                       items: [
                         for (final member in members)
                           DropdownMenuItem<String>(
                             value: member.id,
-                            child: Text(member.name ?? 'Unnamed'),
+                            child: Text(member.name ?? context.tr('noNameLabel')),
                           ),
                       ],
                       onChanged: (value) {
@@ -137,9 +141,9 @@ class _ChatScreenState extends State<ChatScreen> {
                     Expanded(
                       child: TextField(
                         controller: _messageController,
-                        decoration: const InputDecoration(
-                          hintText: 'Type a message',
-                          border: OutlineInputBorder(),
+                        decoration: InputDecoration(
+                          hintText: context.tr('typeMessageHint'),
+                          border: const OutlineInputBorder(),
                         ),
                         minLines: 1,
                         maxLines: 3,
@@ -147,6 +151,7 @@ class _ChatScreenState extends State<ChatScreen> {
                     ),
                     IconButton(
                       icon: const Icon(Icons.send),
+                      tooltip: context.tr('sendAction'),
                       onPressed: _sendMessage,
                     ),
                   ],

--- a/FamilyAppFlutter/lib/screens/cloud_call_screen.dart
+++ b/FamilyAppFlutter/lib/screens/cloud_call_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
+
 /// Placeholder for a screen that would host a cloud-based call.
 /// Displays a message indicating that no call is active.
 class CloudCallScreen extends StatelessWidget {
@@ -8,8 +10,8 @@ class CloudCallScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Cloud Call')),
-      body: const Center(child: Text('No active call.')),
+      appBar: AppBar(title: Text(context.tr('cloudCall'))),
+      body: Center(child: Text(context.tr('noActiveCallLabel'))),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/edit_hobbies_screen.dart
+++ b/FamilyAppFlutter/lib/screens/edit_hobbies_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/family_member.dart';
 import '../providers/family_data.dart';
 
@@ -38,17 +39,21 @@ class _EditHobbiesScreenState extends State<EditHobbiesScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final memberName = widget.member.name?.isNotEmpty == true
+        ? widget.member.name!
+        : context.tr('memberTitle');
+    final title = '${context.tr('editHobbiesAction')} – $memberName';
     return Scaffold(
-      appBar: AppBar(title: Text('Edit hobbies – ${widget.member.name ?? ''}'.trim())),
+      appBar: AppBar(title: Text(title)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
             TextField(
               controller: _controller,
-              decoration: const InputDecoration(
-                labelText: 'Hobbies',
-                hintText: 'Describe hobbies, interests and skills',
+              decoration: InputDecoration(
+                labelText: context.tr('fieldHobbies'),
+                hintText: context.tr('hobbiesHint'),
               ),
               maxLines: 5,
             ),
@@ -58,7 +63,7 @@ class _EditHobbiesScreenState extends State<EditHobbiesScreen> {
               child: FilledButton.icon(
                 onPressed: _save,
                 icon: const Icon(Icons.save),
-                label: const Text('Save'),
+                label: Text(context.tr('saveAction')),
               ),
             ),
           ],

--- a/FamilyAppFlutter/lib/screens/friends_screen.dart
+++ b/FamilyAppFlutter/lib/screens/friends_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/friend.dart';
 import '../providers/friends_data.dart';
 import 'add_friend_screen.dart';
@@ -12,11 +13,14 @@ class FriendsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Friends')),
+      appBar: AppBar(title: Text(context.tr('friends'))),
       body: Consumer<FriendsData>(
         builder: (context, data, _) {
+          if (data.isLoading && data.friends.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
           if (data.friends.isEmpty) {
-            return const Center(child: Text('No friends added.'));
+            return Center(child: Text(context.tr('noFriendsLabel')));
           }
           return ListView.separated(
             itemCount: data.friends.length,
@@ -25,15 +29,16 @@ class FriendsScreen extends StatelessWidget {
               final Friend friend = data.friends[index];
               return ListTile(
                 leading: const Icon(Icons.person),
-                title: Text(friend.name ?? ''),
+                title: Text(friend.name ?? context.tr('noNameLabel')),
                 trailing: IconButton(
                   icon: const Icon(Icons.delete_outline),
-                  onPressed: () {
+                  onPressed: () async {
                     final id = friend.id;
                     if (id != null) {
-                      context.read<FriendsData>().removeFriend(id);
+                      await context.read<FriendsData>().removeFriend(id);
                     }
                   },
+                  tooltip: context.tr('deleteAction'),
                 ),
               );
             },
@@ -46,6 +51,7 @@ class FriendsScreen extends StatelessWidget {
             MaterialPageRoute(builder: (_) => const AddFriendScreen()),
           );
         },
+        tooltip: context.tr('addFriendTitle'),
         child: const Icon(Icons.add),
       ),
     );

--- a/FamilyAppFlutter/lib/screens/gallery_screen.dart
+++ b/FamilyAppFlutter/lib/screens/gallery_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/gallery_item.dart';
 import '../providers/gallery_data.dart';
 import 'add_gallery_item_screen.dart';
@@ -12,11 +13,14 @@ class GalleryScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Gallery')),
+      appBar: AppBar(title: Text(context.tr('gallery'))),
       body: Consumer<GalleryData>(
         builder: (context, data, _) {
+          if (data.isLoading && data.items.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
           if (data.items.isEmpty) {
-            return const Center(child: Text('No gallery items.'));
+            return Center(child: Text(context.tr('galleryEmpty')));
           }
           return GridView.builder(
             padding: const EdgeInsets.all(8.0),
@@ -28,32 +32,36 @@ class GalleryScreen extends StatelessWidget {
             itemCount: data.items.length,
             itemBuilder: (context, index) {
               final GalleryItem item = data.items[index];
-              return Stack(
-                children: [
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Colors.grey.shade200,
-                      borderRadius: BorderRadius.circular(8),
+              return ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    if (item.url != null)
+                      Image.network(
+                        item.url!,
+                        fit: BoxFit.cover,
+                      )
+                    else
+                      Container(color: Colors.grey.shade200),
+                    Positioned(
+                      top: 4,
+                      right: 4,
+                      child: CircleAvatar(
+                        backgroundColor:
+                            Theme.of(context).colorScheme.surface.withOpacity(0.8),
+                        child: IconButton(
+                          onPressed: () async {
+                            final id = item.id ?? item.url ?? '';
+                            await context.read<GalleryData>().removeItem(id);
+                          },
+                          icon: const Icon(Icons.delete, size: 18),
+                          tooltip: context.tr('deleteAction'),
+                        ),
+                      ),
                     ),
-                    alignment: Alignment.center,
-                    padding: const EdgeInsets.all(8),
-                    child: Text(
-                      item.url ?? 'No URL',
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                  Positioned(
-                    top: 0,
-                    right: 0,
-                    child: IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () {
-                        final id = item.id ?? item.url ?? '';
-                        context.read<GalleryData>().removeItem(id);
-                      },
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               );
             },
           );
@@ -66,6 +74,7 @@ class GalleryScreen extends StatelessWidget {
           );
         },
         child: const Icon(Icons.add),
+        tooltip: context.tr('addGalleryItemTitle'),
       ),
     );
   }

--- a/FamilyAppFlutter/lib/screens/home_screen.dart
+++ b/FamilyAppFlutter/lib/screens/home_screen.dart
@@ -20,14 +20,92 @@ import 'tasks_screen.dart';
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
+  static const List<_Feature> _features = [
+    _Feature(
+      titleKey: 'members',
+      descriptionKey: 'membersDescription',
+      icon: Icons.group,
+      builder: (_) => const MembersScreen(),
+    ),
+    _Feature(
+      titleKey: 'tasks',
+      descriptionKey: 'tasksDescription',
+      icon: Icons.checklist,
+      builder: (_) => const TasksScreen(),
+    ),
+    _Feature(
+      titleKey: 'events',
+      descriptionKey: 'eventsDescription',
+      icon: Icons.event,
+      builder: (_) => const EventsScreen(),
+    ),
+    _Feature(
+      titleKey: 'calendar',
+      descriptionKey: 'calendarDescription',
+      icon: Icons.calendar_today,
+      builder: (_) => const CalendarScreen(),
+    ),
+    _Feature(
+      titleKey: 'schedule',
+      descriptionKey: 'scheduleDescription',
+      icon: Icons.schedule,
+      builder: (_) => const ScheduleScreen(),
+    ),
+    _Feature(
+      titleKey: 'scoreboard',
+      descriptionKey: 'scoreboardDescription',
+      icon: Icons.leaderboard,
+      builder: (_) => const ScoreboardScreen(),
+    ),
+    _Feature(
+      titleKey: 'gallery',
+      descriptionKey: 'galleryDescription',
+      icon: Icons.photo_library,
+      builder: (_) => const GalleryScreen(),
+    ),
+    _Feature(
+      titleKey: 'friends',
+      descriptionKey: 'friendsDescription',
+      icon: Icons.people_alt,
+      builder: (_) => const FriendsScreen(),
+    ),
+    _Feature(
+      titleKey: 'chats',
+      descriptionKey: 'chatsDescription',
+      icon: Icons.chat_bubble_outline,
+      builder: (_) => const ChatListScreen(),
+    ),
+    _Feature(
+      titleKey: 'aiSuggestions',
+      descriptionKey: 'aiSuggestionsDescription',
+      icon: Icons.auto_awesome,
+      builder: (_) => const AiSuggestionsScreen(),
+    ),
+    _Feature(
+      titleKey: 'calendarFeed',
+      descriptionKey: 'calendarFeedDescription',
+      icon: Icons.rss_feed,
+      builder: (_) => const CalendarFeedScreen(),
+    ),
+    _Feature(
+      titleKey: 'startCall',
+      descriptionKey: 'startCallDescription',
+      icon: Icons.call,
+      builder: (_) => const CallSetupScreen(),
+    ),
+    _Feature(
+      titleKey: 'cloudCall',
+      descriptionKey: 'cloudCallDescription',
+      icon: Icons.cloud,
+      builder: (_) => const CloudCallScreen(),
+    ),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
     final languageProvider = context.watch<LanguageProvider>();
-    final features = _buildFeatures(context);
-
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.t('homeHubTitle'))),
+      appBar: AppBar(title: Text(context.tr('homeHubTitle'))),
       drawer: Drawer(
         child: ListView(
           padding: EdgeInsets.zero,
@@ -37,15 +115,15 @@ class HomeScreen extends StatelessWidget {
               child: Align(
                 alignment: Alignment.bottomLeft,
                 child: Text(
-                  l10n.t('drawerTitle'),
+                  context.tr('appTitle'),
                   style: const TextStyle(color: Colors.white, fontSize: 24),
                 ),
               ),
             ),
             ListTile(
               leading: const Icon(Icons.language),
-              title: Text(l10n.t('languageMenuTitle')),
-              subtitle: Text(l10n.t('languageMenuSubtitle')),
+              title: Text(context.tr('languageMenuTitle')),
+              subtitle: Text(context.tr('languageMenuSubtitle')),
               trailing: DropdownButtonHideUnderline(
                 child: DropdownButton<Locale>(
                   value: languageProvider.locale,
@@ -59,7 +137,7 @@ class HomeScreen extends StatelessWidget {
                       DropdownMenuItem<Locale>(
                         value: locale,
                         child: Text(
-                          l10n.languageName(locale.languageCode),
+                          context.loc.languageName(locale.languageCode),
                         ),
                       ),
                   ],
@@ -67,11 +145,11 @@ class HomeScreen extends StatelessWidget {
               ),
             ),
             const Divider(height: 1),
-            for (final feature in features)
+            for (final feature in _features)
               ListTile(
                 leading: Icon(feature.icon),
-                title: Text(feature.title),
-                subtitle: Text(feature.description),
+                title: Text(context.tr(feature.titleKey)),
+                subtitle: Text(context.tr(feature.descriptionKey)),
                 onTap: () {
                   Navigator.of(context).pop();
                   Navigator.of(context).push(
@@ -90,97 +168,13 @@ class HomeScreen extends StatelessWidget {
           mainAxisSpacing: 16,
           childAspectRatio: 1.2,
         ),
-        itemCount: features.length,
+        itemCount: _features.length,
         itemBuilder: (context, index) {
-          final feature = features[index];
+          final feature = _features[index];
           return _FeatureCard(feature: feature);
         },
       ),
     );
-  }
-
-  List<_Feature> _buildFeatures(BuildContext context) {
-    final l10n = context.l10n;
-    return [
-      _Feature(
-        title: l10n.t('feature.members.title'),
-        description: l10n.t('feature.members.description'),
-        icon: Icons.group,
-        builder: (_) => const MembersScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.tasks.title'),
-        description: l10n.t('feature.tasks.description'),
-        icon: Icons.checklist,
-        builder: (_) => const TasksScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.events.title'),
-        description: l10n.t('feature.events.description'),
-        icon: Icons.event,
-        builder: (_) => const EventsScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.calendar.title'),
-        description: l10n.t('feature.calendar.description'),
-        icon: Icons.calendar_today,
-        builder: (_) => const CalendarScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.schedule.title'),
-        description: l10n.t('feature.schedule.description'),
-        icon: Icons.schedule,
-        builder: (_) => const ScheduleScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.scoreboard.title'),
-        description: l10n.t('feature.scoreboard.description'),
-        icon: Icons.leaderboard,
-        builder: (_) => const ScoreboardScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.gallery.title'),
-        description: l10n.t('feature.gallery.description'),
-        icon: Icons.photo_library,
-        builder: (_) => const GalleryScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.friends.title'),
-        description: l10n.t('feature.friends.description'),
-        icon: Icons.people_alt,
-        builder: (_) => const FriendsScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.chats.title'),
-        description: l10n.t('feature.chats.description'),
-        icon: Icons.chat_bubble_outline,
-        builder: (_) => const ChatListScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.ai.title'),
-        description: l10n.t('feature.ai.description'),
-        icon: Icons.auto_awesome,
-        builder: (_) => const AiSuggestionsScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.calendarFeed.title'),
-        description: l10n.t('feature.calendarFeed.description'),
-        icon: Icons.rss_feed,
-        builder: (_) => const CalendarFeedScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.callSetup.title'),
-        description: l10n.t('feature.callSetup.description'),
-        icon: Icons.call,
-        builder: (_) => const CallSetupScreen(),
-      ),
-      _Feature(
-        title: l10n.t('feature.cloudCall.title'),
-        description: l10n.t('feature.cloudCall.description'),
-        icon: Icons.cloud,
-        builder: (_) => const CloudCallScreen(),
-      ),
-    ];
   }
 }
 
@@ -210,12 +204,12 @@ class _FeatureCard extends StatelessWidget {
               Icon(feature.icon, size: 40, color: Theme.of(context).colorScheme.primary),
               const SizedBox(height: 16),
               Text(
-                feature.title,
+                context.tr(feature.titleKey),
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               const SizedBox(height: 8),
               Text(
-                feature.description,
+                context.tr(feature.descriptionKey),
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: Theme.of(context).textTheme.bodySmall?.color,
                     ),
@@ -229,14 +223,14 @@ class _FeatureCard extends StatelessWidget {
 }
 
 class _Feature {
-  final String title;
-  final String description;
+  final String titleKey;
+  final String descriptionKey;
   final IconData icon;
   final WidgetBuilder builder;
 
   const _Feature({
-    required this.title,
-    required this.description,
+    required this.titleKey,
+    required this.descriptionKey,
     required this.icon,
     required this.builder,
   });

--- a/FamilyAppFlutter/lib/screens/member_detail_screen.dart
+++ b/FamilyAppFlutter/lib/screens/member_detail_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
+import '../models/family_member.dart';
 import '../providers/family_data.dart';
 import 'add_member_screen.dart';
 import 'edit_documents_screen.dart';
@@ -20,17 +21,19 @@ class MemberDetailScreen extends StatelessWidget {
         final member = data.memberById(memberId);
         if (member == null) {
           return Scaffold(
-            appBar: AppBar(title: const Text('Member')),
-            body: const Center(child: Text('Member not found.')),
+            appBar: AppBar(title: Text(context.tr('memberTitle'))),
+            body: Center(child: Text(context.tr('memberNotFound'))),
           );
         }
         return Scaffold(
           appBar: AppBar(
-            title: Text(member.name?.isNotEmpty == true ? member.name! : 'Member'),
+            title: Text(member.name?.isNotEmpty == true
+                ? member.name!
+                : context.tr('memberTitle')),
             actions: [
               IconButton(
                 icon: const Icon(Icons.edit),
-                tooltip: 'Edit member',
+                tooltip: context.tr('editMember'),
                 onPressed: () async {
                   await Navigator.of(context).push(
                     MaterialPageRoute(
@@ -44,54 +47,67 @@ class MemberDetailScreen extends StatelessWidget {
           body: ListView(
             padding: const EdgeInsets.all(16),
             children: [
+              _MemberAvatar(member: member),
+              const SizedBox(height: 16),
               _InfoTile(
-                title: 'Relationship',
+                title: context.tr('fieldRelationship'),
                 value: member.relationship,
                 icon: Icons.group,
               ),
               _InfoTile(
-                title: 'Phone',
+                title: context.tr('fieldPhone'),
                 value: member.phone,
                 icon: Icons.phone,
               ),
               _InfoTile(
-                title: 'Email',
+                title: context.tr('fieldEmail'),
                 value: member.email,
                 icon: Icons.email,
               ),
               _InfoTile(
-                title: 'Social networks',
+                title: context.tr('socialNetworksSection'),
                 value: member.socialMedia,
                 icon: Icons.share,
               ),
               _InfoTile(
-                title: 'Avatar URL',
-                value: member.avatarUrl,
-                icon: Icons.image,
+                title: context.tr('documentsSummaryLabel'),
+                value: member.documents,
+                icon: Icons.description,
               ),
               if (member.birthday != null)
                 ListTile(
                   leading: const Icon(Icons.cake),
-                  title: const Text('Birthday'),
-                  subtitle: Text(DateFormat('dd.MM.yyyy').format(member.birthday!)),
+                  title: Text(context.tr('birthdayLabel')),
+                  subtitle: Text(
+                    context.loc.formatDate(member.birthday!, withTime: false),
+                  ),
                 ),
               if (member.hobbies?.isNotEmpty == true)
                 Card(
                   margin: const EdgeInsets.symmetric(vertical: 12),
                   child: ListTile(
                     leading: const Icon(Icons.local_activity),
-                    title: const Text('Hobbies'),
+                    title: Text(context.tr('fieldHobbies')),
                     subtitle: Text(member.hobbies!),
                   ),
                 ),
-              if (member.documents?.isNotEmpty == true)
-                Card(
-                  margin: const EdgeInsets.symmetric(vertical: 12),
-                  child: ListTile(
-                    leading: const Icon(Icons.description),
-                    title: const Text('Important documents'),
-                    subtitle: Text(member.documents!),
-                  ),
+              if (member.documentsList?.isNotEmpty == true)
+                _EntriesSection(
+                  title: context.tr('documentsSection'),
+                  entries: member.documentsList!,
+                  prefix: 'documentType',
+                ),
+              if (member.socialNetworks?.isNotEmpty == true)
+                _EntriesSection(
+                  title: context.tr('socialNetworksSection'),
+                  entries: member.socialNetworks!,
+                  prefix: 'socialNetwork',
+                ),
+              if (member.messengers?.isNotEmpty == true)
+                _EntriesSection(
+                  title: context.tr('messengersSection'),
+                  entries: member.messengers!,
+                  prefix: 'messenger',
                 ),
               const SizedBox(height: 16),
               Wrap(
@@ -107,7 +123,7 @@ class MemberDetailScreen extends StatelessWidget {
                       );
                     },
                     icon: const Icon(Icons.folder_open),
-                    label: const Text('View documents'),
+                    label: Text(context.tr('viewDocuments')),
                   ),
                   OutlinedButton.icon(
                     onPressed: () {
@@ -118,7 +134,7 @@ class MemberDetailScreen extends StatelessWidget {
                       );
                     },
                     icon: const Icon(Icons.edit_document),
-                    label: const Text('Edit documents'),
+                    label: Text(context.tr('editDocumentsAction')),
                   ),
                   FilledButton.icon(
                     onPressed: () {
@@ -129,7 +145,7 @@ class MemberDetailScreen extends StatelessWidget {
                       );
                     },
                     icon: const Icon(Icons.sports_esports),
-                    label: const Text('View hobbies'),
+                    label: Text(context.tr('viewHobbiesAction')),
                   ),
                   OutlinedButton.icon(
                     onPressed: () {
@@ -140,7 +156,7 @@ class MemberDetailScreen extends StatelessWidget {
                       );
                     },
                     icon: const Icon(Icons.brush),
-                    label: const Text('Edit hobbies'),
+                    label: Text(context.tr('editHobbiesAction')),
                   ),
                 ],
               ),
@@ -148,6 +164,34 @@ class MemberDetailScreen extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class _MemberAvatar extends StatelessWidget {
+  const _MemberAvatar({required this.member});
+
+  final FamilyMember member;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: CircleAvatar(
+        radius: 48,
+        backgroundImage:
+            member.avatarUrl != null ? NetworkImage(member.avatarUrl!) : null,
+        child: member.avatarUrl == null
+            ? Text(
+                member.name != null && member.name!.isNotEmpty
+                    ? member.name!.substring(0, 1).toUpperCase()
+                    : '?',
+                style: Theme.of(context)
+                    .textTheme
+                    .headlineMedium
+                    ?.copyWith(color: Colors.white),
+              )
+            : null,
+      ),
     );
   }
 }
@@ -172,6 +216,47 @@ class _InfoTile extends StatelessWidget {
       leading: Icon(icon),
       title: Text(title),
       subtitle: Text(value!),
+    );
+  }
+}
+
+class _EntriesSection extends StatelessWidget {
+  const _EntriesSection({
+    required this.title,
+    required this.entries,
+    required this.prefix,
+  });
+
+  final String title;
+  final List<Map<String, String>> entries;
+  final String prefix;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final entry in entries)
+                  Chip(
+                    label: Text(
+                      '${context.tr("$prefix.${entry['type'] ?? 'other'}")}: ${entry['value'] ?? ''}',
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/FamilyAppFlutter/lib/screens/member_documents_screen.dart
+++ b/FamilyAppFlutter/lib/screens/member_documents_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/family_member.dart';
 
 /// Shows documents for a specific family member.
@@ -11,12 +12,20 @@ class MemberDocumentsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final docs = member.documentsList ?? const <Map<String, String>>[];
     final hasSummary = member.documents?.isNotEmpty == true;
+    final title = context.loc.translateWithParams(
+      'memberDocumentsTitle',
+      {
+        'name': member.name?.isNotEmpty == true
+            ? member.name!
+            : context.tr('memberTitle'),
+      },
+    );
     return Scaffold(
       appBar: AppBar(
-        title: Text('${member.name ?? 'Member'} documents'),
+        title: Text(title),
       ),
       body: (docs.isEmpty && !hasSummary)
-          ? const Center(child: Text('No documents available.'))
+          ? Center(child: Text(context.tr('noDocumentsLabel')))
           : ListView(
               padding: const EdgeInsets.all(16),
               children: [
@@ -25,11 +34,15 @@ class MemberDocumentsScreen extends StatelessWidget {
                     margin: const EdgeInsets.only(bottom: 16),
                     child: ListTile(
                       leading: const Icon(Icons.description),
-                      title: const Text('Summary'),
+                      title: Text(context.tr('documentsSummaryLabel')),
                       subtitle: Text(member.documents!),
                     ),
                   ),
-                for (final doc in docs) _DocumentCard(document: doc),
+                for (final doc in docs)
+                  _DocumentCard(
+                    document: doc,
+                    prefix: 'documentType',
+                  ),
               ],
             ),
     );
@@ -38,15 +51,15 @@ class MemberDocumentsScreen extends StatelessWidget {
 
 class _DocumentCard extends StatelessWidget {
   final Map<String, String> document;
-  const _DocumentCard({required this.document});
+  final String prefix;
+  const _DocumentCard({required this.document, required this.prefix});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final title = document['title'] ?? document['name'] ?? 'Document';
-    final cleaned = Map<String, String>.from(document);
-    cleaned.remove('title');
-    cleaned.remove('name');
+    final typeKey = document['type'] ?? 'other';
+    final title =
+        '${context.tr("$prefix.$typeKey")}: ${document['value'] ?? document['description'] ?? ''}';
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       child: Padding(
@@ -55,16 +68,6 @@ class _DocumentCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(title, style: theme.textTheme.titleMedium),
-            const SizedBox(height: 8),
-            if (cleaned.isEmpty)
-              const Text('No additional information')
-            else
-              ...cleaned.entries
-                  .where((entry) => entry.value.trim().isNotEmpty)
-                  .map((entry) => Padding(
-                        padding: const EdgeInsets.only(bottom: 4),
-                        child: Text('${entry.key}: ${entry.value}'),
-                      )),
           ],
         ),
       ),

--- a/FamilyAppFlutter/lib/screens/member_hobbies_screen.dart
+++ b/FamilyAppFlutter/lib/screens/member_hobbies_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/family_member.dart';
 
 /// Shows hobbies for a specific family member.
@@ -10,12 +11,18 @@ class MemberHobbiesScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hobbies = member.hobbies;
+    final name = member.name?.isNotEmpty == true
+        ? member.name!
+        : context.tr('memberTitle');
+    final title = context.loc.translateWithParams('memberHobbiesTitle', {
+      'name': name,
+    });
     return Scaffold(
       appBar: AppBar(
-        title: Text('${member.name ?? 'Member'} hobbies'),
+        title: Text(title),
       ),
       body: hobbies == null || hobbies.isEmpty
-          ? const Center(child: Text('No hobbies found.'))
+          ? Center(child: Text(context.tr('noHobbiesLabel')))
           : Padding(
               padding: const EdgeInsets.all(16),
               child: Text(

--- a/FamilyAppFlutter/lib/screens/schedule_screen.dart
+++ b/FamilyAppFlutter/lib/screens/schedule_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/schedule_item.dart';
 import '../providers/family_data.dart';
 import '../providers/schedule_data.dart';
@@ -16,11 +16,14 @@ class ScheduleScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Schedule')),
+      appBar: AppBar(title: Text(context.tr('schedule'))),
       body: Consumer2<ScheduleData, FamilyData>(
         builder: (context, scheduleData, familyData, _) {
+          if (scheduleData.isLoading && scheduleData.items.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
           if (scheduleData.items.isEmpty) {
-            return const Center(child: Text('No scheduled items.'));
+            return Center(child: Text(context.tr('noScheduleItemsLabel')));
           }
           final items = scheduleData.items.toList()
             ..sort((a, b) => a.dateTime.compareTo(b.dateTime));
@@ -28,7 +31,8 @@ class ScheduleScreen extends StatelessWidget {
             padding: const EdgeInsets.all(12),
             itemBuilder: (context, index) {
               final ScheduleItem item = items[index];
-              final memberName = familyData.memberById(item.memberId ?? '')?.name;
+              final memberName =
+                  familyData.memberById(item.memberId ?? '')?.name ?? '';
               return Card(
                 child: ListTile(
                   leading: const Icon(Icons.calendar_today),
@@ -36,17 +40,27 @@ class ScheduleScreen extends StatelessWidget {
                   subtitle: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(_formatRange(item)),
-                      if (memberName != null && memberName.isNotEmpty)
-                        Text('Member: $memberName'),
+                      Text(context.loc.formatDateRange(
+                        item.dateTime,
+                        item.endDateTime,
+                      )),
+                      if (memberName.isNotEmpty)
+                        Text(
+                          '${context.tr('scheduleMemberLabel')}: $memberName',
+                        ),
                       if (item.location?.isNotEmpty == true)
-                        Text('Location: ${item.location}'),
+                        Text(
+                          '${context.tr('scheduleLocationLabel')}: ${item.location}',
+                        ),
                       if (item.notes?.isNotEmpty == true)
-                        Text('Notes: ${item.notes}'),
+                        Text(
+                          '${context.tr('scheduleNotesLabel')}: ${item.notes}',
+                        ),
                     ],
                   ),
                   trailing: IconButton(
                     icon: const Icon(Icons.delete_outline),
+                    tooltip: context.tr('deleteScheduleAction'),
                     onPressed: () => _confirmDelete(context, item.id),
                   ),
                 ),
@@ -63,34 +77,31 @@ class ScheduleScreen extends StatelessWidget {
             MaterialPageRoute(builder: (_) => const AddScheduleItemScreen()),
           );
         },
+        tooltip: context.tr('addScheduleItemTitle'),
         child: const Icon(Icons.add),
       ),
     );
-  }
-
-  String _formatRange(ScheduleItem item) {
-    final start = DateFormat('dd.MM.yyyy HH:mm').format(item.dateTime);
-    final end = DateFormat('dd.MM.yyyy HH:mm').format(item.endDateTime);
-    return '$start – $end';
   }
 
   void _confirmDelete(BuildContext context, String id) {
     showDialog<void>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Delete entry'),
-        content: const Text('Remove this item from the schedule?'),
+        title: Text(context.tr('deleteScheduleAction')),
+        content: Text(context.tr('deleteScheduleMessage')),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel'),
+            child: Text(context.tr('cancelAction')),
           ),
           FilledButton(
-            onPressed: () {
-              context.read<ScheduleData>().removeItem(id);
-              Navigator.of(ctx).pop();
+            onPressed: () async {
+              await context.read<ScheduleData>().removeItem(id);
+              if (context.mounted) {
+                Navigator.of(ctx).pop();
+              }
             },
-            child: const Text('Delete'),
+            child: Text(context.tr('deleteAction')),
           ),
         ],
       ),

--- a/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
+++ b/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../providers/family_data.dart';
+import '../l10n/app_localizations.dart';
 import '../models/family_member.dart';
 import '../models/task.dart';
+import '../providers/family_data.dart';
 
 /// Displays a leaderboard of family members ordered by total points
 /// earned from completed tasks.  Members with more points appear
@@ -16,18 +17,16 @@ class ScoreboardScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Scoreboard'),
+        title: Text(context.tr('scoreboard')),
       ),
       body: Consumer<FamilyData>(
         builder: (context, data, _) {
-          // Create a copy to sort without mutating the original list.
           final List<FamilyMember> members = List<FamilyMember>.from(data.members);
           final Map<String, int> pointsByMember = {
             for (final member in members)
               member.id: _calculatePointsForMember(member, data.tasks),
           };
 
-          // Sort by points descending, then by name ascending.
           members.sort((a, b) {
             final int pointsA = pointsByMember[a.id] ?? 0;
             final int pointsB = pointsByMember[b.id] ?? 0;
@@ -44,13 +43,17 @@ class ScoreboardScreen extends StatelessWidget {
               return ListTile(
                 leading: CircleAvatar(
                   backgroundColor:
-                      Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
+                      Theme.of(context).colorScheme.primary.withOpacity(0.1),
                   child: Text('${index + 1}'),
                 ),
-                title: Text(member.name?.isNotEmpty == true ? member.name! : 'Unnamed'),
+                title: Text(member.name?.isNotEmpty == true
+                    ? member.name!
+                    : context.tr('noNameLabel')),
                 subtitle: Text(member.relationship ?? ''),
                 trailing: Text(
-                  '$points pts',
+                  context.loc.translateWithParams('pointsSuffix', {
+                    'points': points.toString(),
+                  }),
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
               );

--- a/FamilyAppFlutter/lib/security/encrypted_firestore_service.dart
+++ b/FamilyAppFlutter/lib/security/encrypted_firestore_service.dart
@@ -19,10 +19,13 @@ class EncryptedFirestoreService {
     required DocumentReference<Map<String, dynamic>> ref,
   }) async {
     final snap = await ref.get();
-    if (!snap.exists) return {};
-    final raw = snap.data();
-    if (raw == null) return {};
+    return decode(snap.data());
+  }
 
+  /// Расшифровывает данные из снапшота.
+  Future<Map<String, dynamic>> decode(
+      Map<String, dynamic>? raw) async {
+    if (raw == null) return {};
     final enc = raw['enc'];
     if (enc is String) {
       try {

--- a/FamilyAppFlutter/lib/services/storage_service.dart
+++ b/FamilyAppFlutter/lib/services/storage_service.dart
@@ -1,13 +1,111 @@
-/// Manages general-purpose file storage.  The stub implementation
-/// simply defines methods that do nothing and return defaults.
+import 'dart:io';
+
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:mime/mime.dart';
+import 'package:uuid/uuid.dart';
+
+/// Result of an upload operation containing both the download URL and the
+/// storage path so files can be removed later.
+class StorageUploadResult {
+  final String downloadUrl;
+  final String storagePath;
+
+  const StorageUploadResult({
+    required this.downloadUrl,
+    required this.storagePath,
+  });
+}
+
+/// Provides a thin wrapper around [FirebaseStorage] for uploading and
+/// deleting files.
 class StorageService {
-  Future<void> saveFile(String path, List<int> bytes) async {
-    // Real implementation would write bytes to persistent storage.
-    return;
+  final FirebaseStorage _storage = FirebaseStorage.instance;
+  final Uuid _uuid = const Uuid();
+
+  /// Uploads a file containing a member avatar.
+  Future<StorageUploadResult> uploadMemberAvatar({
+    required String familyId,
+    required File file,
+  }) {
+    return _uploadFile(
+      file: file,
+      segments: ['families', familyId, 'avatars', _uniqueFileName(file.path)],
+    );
   }
 
-  Future<List<int>?> readFile(String path) async {
-    // In a real app this would read and return file contents.
-    return null;
+  /// Uploads a gallery media file.
+  Future<StorageUploadResult> uploadGalleryItem({
+    required String familyId,
+    required File file,
+  }) {
+    return _uploadFile(
+      file: file,
+      segments: ['families', familyId, 'gallery', _uniqueFileName(file.path)],
+    );
+  }
+
+  /// Uploads an attachment that belongs to a chat conversation.
+  Future<StorageUploadResult> uploadChatAttachment({
+    required String familyId,
+    required String chatId,
+    required File file,
+  }) {
+    return _uploadFile(
+      file: file,
+      segments: [
+        'families',
+        familyId,
+        'chats',
+        chatId,
+        _uniqueFileName(file.path),
+      ],
+    );
+  }
+
+  /// Deletes a file by its storage path.
+  Future<void> deleteByPath(String storagePath) async {
+    if (storagePath.isEmpty) return;
+    try {
+      await _storage.ref(storagePath).delete();
+    } catch (_) {
+      // Ignore errors if the file has already been removed or never existed.
+    }
+  }
+
+  /// Deletes a file using the download URL.
+  Future<void> deleteByUrl(String url) async {
+    if (url.isEmpty) return;
+    try {
+      final Reference ref = _storage.refFromURL(url);
+      await ref.delete();
+    } catch (_) {
+      // Ignore errors for missing objects or invalid URLs.
+    }
+  }
+
+  Future<StorageUploadResult> _uploadFile({
+    required File file,
+    required List<String> segments,
+  }) async {
+    final Reference ref = _storage.ref().child(segments.join('/'));
+    final SettableMetadata metadata = SettableMetadata(
+      contentType: lookupMimeType(file.path),
+    );
+    await ref.putFile(file, metadata);
+    final String url = await ref.getDownloadURL();
+    return StorageUploadResult(downloadUrl: url, storagePath: ref.fullPath);
+  }
+
+  String _uniqueFileName(String path) {
+    final String extension = _extension(path);
+    return '${_uuid.v4()}$extension';
+  }
+
+  String _extension(String path) {
+    final int index = path.lastIndexOf('.');
+    if (index == -1 || index == path.length - 1) {
+      return '';
+    }
+    return path.substring(index);
   }
 }

--- a/FamilyAppFlutter/pubspec.yaml
+++ b/FamilyAppFlutter/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   encrypt: ^5.0.3
   pointycastle: ^3.9.1
   flutter_secure_storage: ^9.0.0
+  mime: ^1.0.6
   # For picking images from the gallery and camera
   image_picker: ^1.0.7
   # For accessing device location and calculating distances


### PR DESCRIPTION
## Summary
- integrate the origin/main localization framework and extend it with language menu strings plus legacy helpers for existing widgets
- update application bootstrapping to combine Firebase-backed providers with the persisted language selector
- align schedule, task, AI, home, and member detail screens with the refreshed localization APIs and asynchronous safety guards

## Testing
- not run (flutter toolchain unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d197dc1828832b9d7b48c37d32f344