### PR TITLE
Fix analyzer regressions and update test fakes

### DIFF
--- a/FamilyAppFlutter/lib/screens/add_friend_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_friend_screen.dart
@@ -32,6 +32,7 @@ class _AddFriendScreenState extends State<AddFriendScreen> {
       name: _nameController.text.trim(),
     );
     await context.read<FriendsData>().addFriend(friend);
+    if (!mounted) return;
     Navigator.of(context).pop();
   }
 

--- a/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
@@ -66,6 +66,7 @@ class _AddGalleryItemScreenState extends State<AddGalleryItemScreen> {
       storagePath: _storagePath,
     );
     await context.read<GalleryData>().addItem(item);
+    if (!mounted) return;
     Navigator.of(context).pop();
   }
 

--- a/FamilyAppFlutter/lib/screens/add_member_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_member_screen.dart
@@ -206,6 +206,7 @@ class _AddMemberScreenState extends State<AddMemberScreen> {
     } else {
       await familyData.updateMember(member);
     }
+    if (!mounted) return;
     Navigator.of(context).pop();
   }
 
@@ -456,7 +457,7 @@ class _AddMemberScreenState extends State<AddMemberScreen> {
             child: Column(
               children: [
                 DropdownButtonFormField<String>(
-                  value: entry.type ?? options.first,
+                  initialValue: entry.type ?? options.first,
                   items: [
                     for (final option in options)
                       DropdownMenuItem<String>(

--- a/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_schedule_item_screen.dart
@@ -130,7 +130,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<Duration?>(
-                  value: _duration,
+                  initialValue: _duration,
                   decoration:
                       InputDecoration(labelText: context.tr('scheduleDurationLabel')),
                   items: [
@@ -154,7 +154,7 @@ class _AddScheduleItemScreenState extends State<AddScheduleItemScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String?>(
-                  value: _memberId,
+                  initialValue: _memberId,
                   decoration: InputDecoration(labelText: context.tr('assignToLabel')),
                   items: [
                     DropdownMenuItem<String?>(

--- a/FamilyAppFlutter/lib/screens/add_task_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_task_screen.dart
@@ -128,7 +128,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<TaskStatus>(
-                  value: _status,
+                  initialValue: _status,
                   decoration: InputDecoration(labelText: context.tr('taskStatusLabel')),
                   items: TaskStatus.values
                       .map(
@@ -146,7 +146,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String?>(
-                  value: _assigneeId,
+                  initialValue: _assigneeId,
                   decoration: InputDecoration(labelText: context.tr('assignToLabel')),
                   items: [
                     const DropdownMenuItem<String?>(

--- a/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
+++ b/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
@@ -132,8 +132,10 @@ class _AiSuggestionsScreenState extends State<AiSuggestionsScreen> {
                   width: double.infinity,
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Colors.red.withOpacity(0.08),
-                    border: Border.all(color: Colors.red.withOpacity(0.3)),
+                    color: Colors.red.withValues(alpha: 0.08),
+                    border: Border.all(
+                      color: Colors.red.withValues(alpha: 0.3),
+                    ),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
@@ -159,11 +161,11 @@ class _AiSuggestionsScreenState extends State<AiSuggestionsScreen> {
                               color: Theme.of(context)
                                   .colorScheme
                                   .surface
-                                  .withOpacity(0.6),
+                                  .withValues(alpha: 0.6),
                               border: Border.all(
                                 color: Theme.of(context)
                                     .dividerColor
-                                    .withOpacity(0.3),
+                                    .withValues(alpha: 0.3),
                               ),
                               borderRadius: BorderRadius.circular(10),
                             ),

--- a/FamilyAppFlutter/lib/screens/chat_screen.dart
+++ b/FamilyAppFlutter/lib/screens/chat_screen.dart
@@ -89,7 +89,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                 color: Theme.of(context)
                                     .colorScheme
                                     .primary
-                                    .withOpacity(0.1),
+                                    .withValues(alpha: 0.1),
                                 borderRadius: BorderRadius.circular(12),
                               ),
                               child: Column(

--- a/FamilyAppFlutter/lib/screens/edit_documents_screen.dart
+++ b/FamilyAppFlutter/lib/screens/edit_documents_screen.dart
@@ -112,7 +112,7 @@ class _EditDocumentsScreenState extends State<EditDocumentsScreen> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             DropdownButtonFormField<String>(
-                              value: doc.type ?? _documentOptions.first,
+                              initialValue: doc.type ?? _documentOptions.first,
                               items: [
                                 for (final option in _documentOptions)
                                   DropdownMenuItem<String>(

--- a/FamilyAppFlutter/lib/screens/gallery_screen.dart
+++ b/FamilyAppFlutter/lib/screens/gallery_screen.dart
@@ -49,7 +49,10 @@ class GalleryScreen extends StatelessWidget {
                       right: 4,
                       child: CircleAvatar(
                         backgroundColor:
-                            Theme.of(context).colorScheme.surface.withOpacity(0.8),
+                            Theme.of(context)
+                                .colorScheme
+                                .surface
+                                .withValues(alpha: 0.8),
                         child: IconButton(
                           onPressed: () async {
                             final id = item.id ?? item.url ?? '';
@@ -73,8 +76,8 @@ class GalleryScreen extends StatelessWidget {
             MaterialPageRoute(builder: (_) => const AddGalleryItemScreen()),
           );
         },
-        child: const Icon(Icons.add),
         tooltip: context.tr('addGalleryItemTitle'),
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/FamilyAppFlutter/lib/screens/home_screen.dart
+++ b/FamilyAppFlutter/lib/screens/home_screen.dart
@@ -20,7 +20,7 @@ import 'tasks_screen.dart';
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
-  static const List<_Feature> _features = [
+  static final List<_Feature> _features = [
     _Feature(
       titleKey: 'members',
       descriptionKey: 'membersDescription',

--- a/FamilyAppFlutter/lib/screens/members_screen.dart
+++ b/FamilyAppFlutter/lib/screens/members_screen.dart
@@ -107,8 +107,8 @@ class MembersScreen extends StatelessWidget {
                 MaterialPageRoute(builder: (_) => const AddMemberScreen()),
               );
             },
-            child: const Icon(Icons.add),
             tooltip: context.tr('addMember'),
+            child: const Icon(Icons.add),
           ),
         );
       },

--- a/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
+++ b/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
@@ -43,7 +43,7 @@ class ScoreboardScreen extends StatelessWidget {
               return ListTile(
                 leading: CircleAvatar(
                   backgroundColor:
-                      Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                      Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
                   child: Text('${index + 1}'),
                 ),
                 title: Text(member.name?.isNotEmpty == true

--- a/FamilyAppFlutter/lib/screens/tasks_screen.dart
+++ b/FamilyAppFlutter/lib/screens/tasks_screen.dart
@@ -46,7 +46,8 @@ class TasksScreen extends StatelessWidget {
                       Chip(
                         label: Text(context.tr('taskStatus.${task.status.name}')),
                         backgroundColor:
-                            _statusColor(context, task.status).withOpacity(0.12),
+                            _statusColor(context, task.status)
+                                .withValues(alpha: 0.12),
                       ),
                       if (task.description?.isNotEmpty == true)
                         Padding(

--- a/FamilyAppFlutter/test/widget_test.dart
+++ b/FamilyAppFlutter/test/widget_test.dart
@@ -1,18 +1,176 @@
+import 'dart:io';
+
 import 'package:family_app_flutter/main.dart';
-import 'package:family_app_flutter/providers/chat_provider.dart';
+import 'package:family_app_flutter/models/chat.dart';
+import 'package:family_app_flutter/models/chat_message.dart';
+import 'package:family_app_flutter/models/conversation.dart';
+import 'package:family_app_flutter/models/event.dart';
+import 'package:family_app_flutter/models/family_member.dart';
+import 'package:family_app_flutter/models/friend.dart';
+import 'package:family_app_flutter/models/gallery_item.dart';
+import 'package:family_app_flutter/models/message.dart';
+import 'package:family_app_flutter/models/schedule_item.dart';
+import 'package:family_app_flutter/models/task.dart';
 import 'package:family_app_flutter/providers/language_provider.dart';
+import 'package:family_app_flutter/services/firestore_service.dart';
+import 'package:family_app_flutter/services/storage_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('App smoke test', (WidgetTester tester) async {
     // Создаём минимальный экземпляр приложения с пустым ChatProvider.
-    final chatProvider = ChatProvider();
     final languageProvider = LanguageProvider();
     await tester.pumpWidget(
       MyApp(
-        chatProvider: chatProvider,
+        firestore: _FakeFirestoreService(),
+        storage: _FakeStorageService(),
         languageProvider: languageProvider,
       ),
     );
+    await tester.pump();
   });
+}
+
+class _FakeFirestoreService extends FirestoreService {
+  @override
+  Future<List<FamilyMember>> fetchFamilyMembers(String familyId) async =>
+      const <FamilyMember>[];
+
+  @override
+  Future<void> upsertFamilyMember(String familyId, FamilyMember member) async {}
+
+  @override
+  Future<void> deleteFamilyMember(String familyId, String memberId) async {}
+
+  @override
+  Future<List<Task>> fetchTasks(String familyId) async => const <Task>[];
+
+  @override
+  Future<void> upsertTask(String familyId, Task task) async {}
+
+  @override
+  Future<void> deleteTask(String familyId, String taskId) async {}
+
+  @override
+  Future<List<Event>> fetchEvents(String familyId) async => const <Event>[];
+
+  @override
+  Future<void> upsertEvent(String familyId, Event event) async {}
+
+  @override
+  Future<void> deleteEvent(String familyId, String eventId) async {}
+
+  @override
+  Future<List<ScheduleItem>> fetchScheduleItems(String familyId) async =>
+      const <ScheduleItem>[];
+
+  @override
+  Future<void> upsertScheduleItem(String familyId, ScheduleItem item) async {}
+
+  @override
+  Future<void> deleteScheduleItem(String familyId, String itemId) async {}
+
+  @override
+  Future<List<Friend>> fetchFriends(String familyId) async =>
+      const <Friend>[];
+
+  @override
+  Future<void> upsertFriend(String familyId, Friend friend) async {}
+
+  @override
+  Future<void> deleteFriend(String familyId, String friendId) async {}
+
+  @override
+  Future<List<GalleryItem>> fetchGalleryItems(String familyId) async =>
+      const <GalleryItem>[];
+
+  @override
+  Future<void> upsertGalleryItem(String familyId, GalleryItem item) async {}
+
+  @override
+  Future<void> deleteGalleryItem(String familyId, String itemId) async {}
+
+  @override
+  Future<List<Chat>> fetchChats(String familyId) async => const <Chat>[];
+
+  @override
+  Future<void> upsertChat(String familyId, Chat chat) async {}
+
+  @override
+  Future<void> deleteChat(String familyId, String chatId) async {}
+
+  @override
+  Future<List<ChatMessage>> fetchChatMessages(
+    String familyId,
+    String chatId,
+  ) async => const <ChatMessage>[];
+
+  @override
+  Future<void> upsertChatMessage(
+    String familyId,
+    String chatId,
+    ChatMessage message,
+  ) async {}
+
+  @override
+  Future<void> deleteChatMessages(String familyId, String chatId) async {}
+
+  @override
+  Future<List<Conversation>> fetchConversations(String familyId) async =>
+      const <Conversation>[];
+
+  @override
+  Future<void> upsertConversation(
+    String familyId,
+    Conversation conversation,
+  ) async {}
+
+  @override
+  Future<void> deleteConversation(String familyId, String conversationId) async {}
+
+  @override
+  Future<List<Message>> fetchCallMessages(
+    String familyId,
+    String conversationId,
+  ) async => const <Message>[];
+
+  @override
+  Future<void> upsertCallMessage(
+    String familyId,
+    String conversationId,
+    Message message,
+  ) async {}
+
+  @override
+  Future<void> deleteCallMessages(String familyId, String conversationId) async {}
+}
+
+class _FakeStorageService extends StorageService {
+  static const _emptyUpload =
+      StorageUploadResult(downloadUrl: '', storagePath: '');
+
+  @override
+  Future<StorageUploadResult> uploadMemberAvatar({
+    required String familyId,
+    required File file,
+  }) async => _emptyUpload;
+
+  @override
+  Future<StorageUploadResult> uploadGalleryItem({
+    required String familyId,
+    required File file,
+  }) async => _emptyUpload;
+
+  @override
+  Future<StorageUploadResult> uploadChatAttachment({
+    required String familyId,
+    required String chatId,
+    required File file,
+  }) async => _emptyUpload;
+
+  @override
+  Future<void> deleteByPath(String storagePath) async {}
+
+  @override
+  Future<void> deleteByUrl(String url) async {}
 }


### PR DESCRIPTION
## Summary
- guard navigation calls with mounted checks and adopt `initialValue` on dropdown form fields
- replace deprecated `withOpacity` usage with `withValues` and tidy widget argument order
- relax the HomeScreen feature list const-ness and provide fake services to satisfy the widget smoke test

## Testing
- Not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d19e780738832b8bb5b0b62141d711