### PR TITLE
Fix async context usage in gallery upload

### DIFF
--- a/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_gallery_item_screen.dart
@@ -31,17 +31,19 @@ class _AddGalleryItemScreenState extends State<AddGalleryItemScreen> {
 
   Future<void> _pickFile() async {
     final storage = context.read<StorageService>();
+    final familyId = context.read<GalleryData>().familyId;
     final result = await FilePicker.platform.pickFiles(type: FileType.image);
     if (result == null || result.files.isEmpty) return;
     final path = result.files.single.path;
     if (path == null) return;
+    if (!mounted) return;
     setState(() {
       _uploading = true;
     });
     final file = File(path);
     try {
       final upload = await storage.uploadGalleryItem(
-        familyId: context.read<GalleryData>().familyId,
+        familyId: familyId,
         file: file,
       );
       setState(() {

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,3 @@
+# Merge Notes
+
+This file is intentionally added to ensure `agent.md` is part of the merge file list.


### PR DESCRIPTION
## Summary
- guard the add gallery item screen from using BuildContext across async gaps by caching the family id and verifying the widget is still mounted before updating state
- add an `agent.md` file to ensure it is included in the merge file list

## Testing
- flutter analyze *(fails: `flutter` command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a68265c0832b969877477145289e