### PR TITLE
Resolve Flutter analyzer errors

### DIFF
--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 import 'config/app_config.dart';

--- a/FamilyAppFlutter/lib/screens/add_task_screen.dart
+++ b/FamilyAppFlutter/lib/screens/add_task_screen.dart
@@ -74,7 +74,7 @@ class _AddTaskScreenState extends State<AddTaskScreen> {
     if (mounted) {
       Navigator.of(context).pop();
     }
-
+  }
 
   @override
   void dispose() {

--- a/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
+++ b/FamilyAppFlutter/lib/screens/ai_suggestions_screen.dart
@@ -163,11 +163,11 @@ class _AiSuggestionsScreenState extends State<AiSuggestionsScreen> {
                               color: Theme.of(context)
                                   .colorScheme
                                   .surface
-                                  .withOpacity(0.6),
+                                  .withValues(alpha: 0.6),
                               border: Border.all(
                                 color: Theme.of(context)
                                     .dividerColor
-                                    .withOpacity(0.3),
+                                    .withValues(alpha: 0.3),
                               ),
                               borderRadius: BorderRadius.circular(10),
                             ),

--- a/FamilyAppFlutter/lib/screens/chat_screen.dart
+++ b/FamilyAppFlutter/lib/screens/chat_screen.dart
@@ -89,7 +89,7 @@ class _ChatScreenState extends State<ChatScreen> {
                                 color: Theme.of(context)
                                     .colorScheme
                                     .primary
-                                    .withOpacity(0.1),
+                                    .withValues(alpha: 0.1),
                                 borderRadius: BorderRadius.circular(12),
                               ),
                               child: Column(

--- a/FamilyAppFlutter/lib/screens/gallery_screen.dart
+++ b/FamilyAppFlutter/lib/screens/gallery_screen.dart
@@ -80,7 +80,6 @@ class GalleryScreen extends StatelessWidget {
         },
         tooltip: context.tr('addGalleryItemTitle'),
         child: const Icon(Icons.add),
-        tooltip: context.tr('addGalleryItemTitle'),
       ),
     );
   }

--- a/FamilyAppFlutter/lib/screens/home_screen.dart
+++ b/FamilyAppFlutter/lib/screens/home_screen.dart
@@ -19,7 +19,7 @@ import 'tasks_screen.dart';
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
-  static const List<_Feature> _features = [
+  static final List<_Feature> _features = [
     _Feature(
       titleKey: 'members',
       descriptionKey: 'membersDescription',

--- a/FamilyAppFlutter/lib/screens/members_screen.dart
+++ b/FamilyAppFlutter/lib/screens/members_screen.dart
@@ -109,7 +109,6 @@ class MembersScreen extends StatelessWidget {
             },
             tooltip: context.tr('addMember'),
             child: const Icon(Icons.add),
-            tooltip: context.tr('addMember'),
           ),
         );
       },

--- a/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
+++ b/FamilyAppFlutter/lib/screens/scoreboard_screen.dart
@@ -43,7 +43,7 @@ class ScoreboardScreen extends StatelessWidget {
               return ListTile(
                 leading: CircleAvatar(
                   backgroundColor:
-                      Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                      Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
                   child: Text('${index + 1}'),
                 ),
                 title: Text(member.name?.isNotEmpty == true


### PR DESCRIPTION
## Summary
- remove the unused localization import from the app entry point
- close the add-task save handler properly and clean up floating action button tooltips
- replace deprecated color opacity calls and relax the home feature registry from const

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1afd0495c832b9a5eec1729b8f6d5