### PR TITLE
Prevent duplicate Firebase initialization

### DIFF
--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -21,9 +21,13 @@ import 'storage/hive_secure.dart';
 /// services required by the application.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } else {
+    Firebase.app();
+  }
   await Hive.initFlutter();
   await HiveSecure.ensureDek();
 


### PR DESCRIPTION
## Summary
- avoid creating a second default Firebase app by checking the existing instances before calling `Firebase.initializeApp`

## Testing
- `flutter test` *(fails: flutter sdk unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b5f2ed68832ba0902580affe3843