### PR TITLE
Pin build_runner to avoid Hive generator conflict

### DIFF
--- a/FamilyAppFlutter/pubspec.yaml
+++ b/FamilyAppFlutter/pubspec.yaml
@@ -38,7 +38,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.2
-  build_runner: ^2.4.13
+  build_runner: 2.4.13
   hive_generator: ^2.0.1
 
 flutter:


### PR DESCRIPTION
## Summary
- pin `build_runner` to version `2.4.13` to avoid conflicts with `hive_generator`

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2523e68dc832b8b23ff68c275b0eb