### PR TITLE
Restore FamilyData member lookup helper

### DIFF
--- a/FamilyAppFlutter/lib/providers/family_data.dart
+++ b/FamilyAppFlutter/lib/providers/family_data.dart
@@ -18,6 +18,18 @@ class FamilyData extends ChangeNotifier {
   final List<Task> tasks = <Task>[];
   final List<Event> events = <Event>[];
 
+  FamilyMember? memberById(String? memberId) {
+    if (memberId == null) {
+      return null;
+    }
+    for (final FamilyMember member in members) {
+      if (member.id == memberId) {
+        return member;
+      }
+    }
+    return null;
+  }
+
   StreamSubscription<List<FamilyMember>>? _membersSub;
   StreamSubscription<List<Task>>? _tasksSub;
   StreamSubscription<List<Event>>? _eventsSub;


### PR DESCRIPTION
## Summary
- reintroduce the `memberById` helper on `FamilyData` so the chat screen and other widgets can resolve members by id

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d25805e748832b9a18fa00ddaf092e