### PR TITLE
Fix analyzer failures after Firebase SDK updates

### DIFF
--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
@@ -40,7 +39,7 @@ Future<void> main() async {
   await migrationService.migrateLegacyHiveData(AppConfig.familyId);
 
   final StorageService storageService = StorageService();
-  final Box settingsBox = await Hive.openBox('settings');
+  final Box<dynamic> settingsBox = await Hive.openBox<dynamic>('settings');
   final LanguageProvider languageProvider = LanguageProvider(box: settingsBox);
 
   runApp(

--- a/FamilyAppFlutter/lib/models/conversation.dart
+++ b/FamilyAppFlutter/lib/models/conversation.dart
@@ -36,7 +36,7 @@ class Conversation {
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -50,8 +50,8 @@ class Conversation {
       title: openData['title'] as String?,
       avatarUrl: openData['avatarUrl'] as String?,
       lastMessagePreview: openData['lastMessagePreview'] as String?,
-      createdAt: createdAt ?? _parseDate(openData['createdAt']),
-      updatedAt: updatedAt ?? _parseDate(openData['updatedAt']),
+      createdAt: createdAt ?? parseDate(openData['createdAt']),
+      updatedAt: updatedAt ?? parseDate(openData['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/models/event.dart
+++ b/FamilyAppFlutter/lib/models/event.dart
@@ -35,7 +35,7 @@ class Event {
       };
 
   static Event fromDecodableMap(Map<String, dynamic> map) {
-    DateTime _parseDate(dynamic value) {
+    DateTime parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value) ?? DateTime.now();
@@ -43,14 +43,14 @@ class Event {
       return DateTime.now();
     }
 
-    List<String> _parseList(dynamic value) {
+    List<String> parseList(dynamic value) {
       if (value is List) {
         return value.map((dynamic e) => e.toString()).toList();
       }
       return const <String>[];
     }
 
-    DateTime? _parseNullable(dynamic value) {
+    DateTime? parseNullable(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -61,12 +61,12 @@ class Event {
     return Event(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
-      startDateTime: _parseDate(map['startDateTime']),
-      endDateTime: _parseDate(map['endDateTime']),
+      startDateTime: parseDate(map['startDateTime']),
+      endDateTime: parseDate(map['endDateTime']),
       description: map['description'] as String?,
-      participantIds: _parseList(map['participantIds']),
-      createdAt: _parseNullable(map['createdAt']),
-      updatedAt: _parseNullable(map['updatedAt']),
+      participantIds: parseList(map['participantIds']),
+      createdAt: parseNullable(map['createdAt']),
+      updatedAt: parseNullable(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/family_member.dart
+++ b/FamilyAppFlutter/lib/models/family_member.dart
@@ -61,22 +61,24 @@ class FamilyMember {
       };
 
   static FamilyMember fromDecodableMap(Map<String, dynamic> map) {
-    List<Map<String, String>>? _mapList(dynamic value) {
+    List<Map<String, String>>? mapList(dynamic value) {
       if (value is List) {
         return value
-            .whereType<Map>()
-            .map((dynamic entry) => entry.map(
-                  (dynamic key, dynamic val) => MapEntry(
-                    key.toString(),
-                    val?.toString() ?? '',
-                  ),
-                ))
+            .whereType<Map<dynamic, dynamic>>()
+            .map(
+              (Map<dynamic, dynamic> entry) => entry.map<String, String>(
+                (dynamic key, dynamic val) => MapEntry<String, String>(
+                  key.toString(),
+                  val?.toString() ?? '',
+                ),
+              ),
+            )
             .toList();
       }
       return null;
     }
 
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) {
         return value;
       }
@@ -90,7 +92,7 @@ class FamilyMember {
       id: (map['id'] ?? '').toString(),
       name: map['name'] as String?,
       relationship: map['relationship'] as String?,
-      birthday: _parseDate(map['birthday']),
+      birthday: parseDate(map['birthday']),
       phone: map['phone'] as String?,
       email: map['email'] as String?,
       avatarUrl: map['avatarUrl'] as String?,
@@ -98,11 +100,11 @@ class FamilyMember {
       socialMedia: map['socialMedia'] as String?,
       hobbies: map['hobbies'] as String?,
       documents: map['documents'] as String?,
-      documentsList: _mapList(map['documentsList']),
-      socialNetworks: _mapList(map['socialNetworks']),
-      messengers: _mapList(map['messengers']),
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      documentsList: mapList(map['documentsList']),
+      socialNetworks: mapList(map['socialNetworks']),
+      messengers: mapList(map['messengers']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/models/friend.dart
+++ b/FamilyAppFlutter/lib/models/friend.dart
@@ -29,7 +29,7 @@ class Friend {
       };
 
   static Friend fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -42,8 +42,8 @@ class Friend {
       name: map['name'] as String?,
       phone: map['phone'] as String?,
       notes: map['notes'] as String?,
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/gallery_item.dart
+++ b/FamilyAppFlutter/lib/models/gallery_item.dart
@@ -29,7 +29,7 @@ class GalleryItem {
       };
 
   static GalleryItem fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -42,8 +42,8 @@ class GalleryItem {
       url: map['url'] as String?,
       storagePath: map['storagePath'] as String?,
       caption: map['caption'] as String?,
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/message.dart
+++ b/FamilyAppFlutter/lib/models/message.dart
@@ -66,7 +66,7 @@ class Message {
     required String iv,
     required int encVersion,
   }) {
-    DateTime _parseDate(dynamic value) {
+    DateTime parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value) ?? DateTime.now();
@@ -74,7 +74,7 @@ class Message {
       return DateTime.now();
     }
 
-    DateTime? _parseNullable(dynamic value) {
+    DateTime? parseNullable(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -82,7 +82,7 @@ class Message {
       return null;
     }
 
-    MessageType _parseType(dynamic value) {
+    MessageType parseType(dynamic value) {
       final String name = value?.toString() ?? 'text';
       return MessageType.values.firstWhere(
         (MessageType type) => type.name == name,
@@ -90,7 +90,7 @@ class Message {
       );
     }
 
-    MessageStatus _parseStatus(dynamic value) {
+    MessageStatus parseStatus(dynamic value) {
       final String name = value?.toString() ?? 'sent';
       return MessageStatus.values.firstWhere(
         (MessageStatus status) => status.name == name,
@@ -98,8 +98,8 @@ class Message {
       );
     }
 
-    DateTime createdAt = _parseDate(metadata['createdAt']);
-    final DateTime? legacyCreated = _parseNullable(openData['createdAtLocal']);
+    DateTime createdAt = parseDate(metadata['createdAt']);
+    final DateTime? legacyCreated = parseNullable(openData['createdAtLocal']);
     if (legacyCreated != null) {
       createdAt = legacyCreated;
     }
@@ -107,13 +107,13 @@ class Message {
       id: id,
       conversationId: conversationId,
       senderId: metadata['senderId']?.toString() ?? '',
-      type: _parseType(metadata['type']),
+      type: parseType(metadata['type']),
       ciphertext: ciphertext,
       iv: iv,
       encVersion: encVersion,
       createdAt: createdAt,
-      editedAt: _parseNullable(metadata['editedAt']),
-      status: _parseStatus(metadata['status']),
+      editedAt: parseNullable(metadata['editedAt']),
+      status: parseStatus(metadata['status']),
       openData: openData,
     );
   }

--- a/FamilyAppFlutter/lib/models/schedule_item.dart
+++ b/FamilyAppFlutter/lib/models/schedule_item.dart
@@ -41,7 +41,7 @@ class ScheduleItem {
       };
 
   static ScheduleItem fromDecodableMap(Map<String, dynamic> map) {
-    DateTime _parseDate(dynamic value) {
+    DateTime parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value) ?? DateTime.now();
@@ -49,7 +49,7 @@ class ScheduleItem {
       return DateTime.now();
     }
 
-    Duration? _parseDuration(dynamic value) {
+    Duration? parseDuration(dynamic value) {
       if (value is int) return Duration(minutes: value);
       if (value is String && value.isNotEmpty) {
         final int? minutes = int.tryParse(value);
@@ -58,7 +58,7 @@ class ScheduleItem {
       return null;
     }
 
-    DateTime? _parseNullable(dynamic value) {
+    DateTime? parseNullable(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -69,13 +69,13 @@ class ScheduleItem {
     return ScheduleItem(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
-      dateTime: _parseDate(map['dateTime']),
-      duration: _parseDuration(map['duration']),
+      dateTime: parseDate(map['dateTime']),
+      duration: parseDuration(map['duration']),
       location: map['location'] as String?,
       notes: map['notes'] as String?,
       memberId: map['memberId'] as String?,
-      createdAt: _parseNullable(map['createdAt']),
-      updatedAt: _parseNullable(map['updatedAt']),
+      createdAt: parseNullable(map['createdAt']),
+      updatedAt: parseNullable(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/task.dart
+++ b/FamilyAppFlutter/lib/models/task.dart
@@ -40,7 +40,7 @@ class Task {
       };
 
   static Task fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -52,7 +52,7 @@ class Task {
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
       description: map['description'] as String?,
-      dueDate: _parseDate(map['dueDate']),
+      dueDate: parseDate(map['dueDate']),
       status: TaskStatus.values.firstWhere(
         (TaskStatus status) => status.name == map['status'],
         orElse: () => TaskStatus.todo,
@@ -61,8 +61,8 @@ class Task {
       points: map['points'] is int
           ? map['points'] as int
           : int.tryParse('${map['points']}'),
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/providers/family_data.dart
+++ b/FamilyAppFlutter/lib/providers/family_data.dart
@@ -147,6 +147,66 @@ class FamilyData extends ChangeNotifier {
     await _firestore.deleteEvent(familyId, id);
   }
 
+  FamilyMember? memberById(String id) {
+    if (id.isEmpty) {
+      return null;
+    }
+    try {
+      return members.firstWhere((FamilyMember member) => member.id == id);
+    } on StateError {
+      return null;
+    }
+  }
+
+  Future<void> updateMemberDocuments(
+    String memberId, {
+    String? summary,
+    List<Map<String, String>>? documentsList,
+  }) async {
+    final int index =
+        members.indexWhere((FamilyMember member) => member.id == memberId);
+    if (index == -1) {
+      return;
+    }
+    final FamilyMember updated = members[index].copyWith(
+      documents: summary,
+      documentsList: documentsList,
+      updatedAt: DateTime.now(),
+    );
+    members[index] = updated;
+    notifyListeners();
+    await _firestore.updateFamilyMember(familyId, updated);
+  }
+
+  Future<void> updateMemberHobbies(String memberId, String? hobbies) async {
+    final int index =
+        members.indexWhere((FamilyMember member) => member.id == memberId);
+    if (index == -1) {
+      return;
+    }
+    final FamilyMember updated = members[index].copyWith(
+      hobbies: hobbies,
+      updatedAt: DateTime.now(),
+    );
+    members[index] = updated;
+    notifyListeners();
+    await _firestore.updateFamilyMember(familyId, updated);
+  }
+
+  Future<void> updateTaskStatus(String taskId, TaskStatus status) async {
+    final int index = tasks.indexWhere((Task task) => task.id == taskId);
+    if (index == -1) {
+      return;
+    }
+    final Task updated = tasks[index].copyWith(
+      status: status,
+      updatedAt: DateTime.now(),
+    );
+    tasks[index] = updated;
+    notifyListeners();
+    await _firestore.updateTask(familyId, updated);
+  }
+
   @override
   void dispose() {
     _membersSub?.cancel();

--- a/FamilyAppFlutter/lib/screens/call_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_screen.dart
@@ -20,14 +20,14 @@ class CallScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final familyData = Provider.of<FamilyData>(context, listen: false);
-    final participants = conversation.memberIds
-        .map((id) => familyData.members.firstWhere(
-              (member) => member.id == id,
-              orElse: () => FamilyMember(
-                id: '',
+    final List<FamilyMember> participants = conversation.participantIds
+        .map(
+          (String id) => familyData.memberById(id) ??
+              FamilyMember(
+                id: id,
                 name: context.tr('unknownMemberLabel'),
               ),
-            ))
+        )
         .toList();
 
     final typeLabel =

--- a/FamilyAppFlutter/lib/screens/call_setup_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_setup_screen.dart
@@ -49,7 +49,7 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
     final conversation = Conversation(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       title: title,
-      memberIds: selected,
+      participantIds: selected,
       createdAt: DateTime.now(),
     );
     Navigator.of(context).push(

--- a/FamilyAppFlutter/lib/screens/friends_screen.dart
+++ b/FamilyAppFlutter/lib/screens/friends_screen.dart
@@ -33,10 +33,7 @@ class FriendsScreen extends StatelessWidget {
                 trailing: IconButton(
                   icon: const Icon(Icons.delete_outline),
                   onPressed: () async {
-                    final id = friend.id;
-                    if (id != null) {
-                      await context.read<FriendsData>().removeFriend(id);
-                    }
+                    await context.read<FriendsData>().removeFriend(friend.id);
                   },
                   tooltip: context.tr('deleteAction'),
                 ),

--- a/FamilyAppFlutter/lib/screens/gallery_screen.dart
+++ b/FamilyAppFlutter/lib/screens/gallery_screen.dart
@@ -57,8 +57,9 @@ class GalleryScreen extends StatelessWidget {
 
                         child: IconButton(
                           onPressed: () async {
-                            final id = item.id ?? item.url ?? '';
-                            await context.read<GalleryData>().removeItem(id);
+                            await context
+                                .read<GalleryData>()
+                                .removeItem(item.id);
                           },
                           icon: const Icon(Icons.delete, size: 18),
                           tooltip: context.tr('deleteAction'),

--- a/FamilyAppFlutter/lib/services/firebase_service.dart
+++ b/FamilyAppFlutter/lib/services/firebase_service.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/foundation.dart';
 
 import '../firebase_options.dart';
 
@@ -30,21 +29,10 @@ class FirebaseService {
     }
 
     final FirebaseFirestore firestore = FirebaseFirestore.instance;
-
-    if (kIsWeb) {
-      try {
-        await firestore.enablePersistence(
-          const PersistenceSettings(synchronizeTabs: true),
-        );
-      } on FirebaseException {
-        // On some browsers persistence may already be enabled or unsupported.
-      }
-    } else {
-      firestore.settings = const Settings(
-        persistenceEnabled: true,
-        cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
-      );
-    }
+    firestore.settings = const Settings(
+      persistenceEnabled: true,
+      cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+    );
 
     _initialized = true;
   }

--- a/FamilyAppFlutter/lib/services/firestore_service.dart
+++ b/FamilyAppFlutter/lib/services/firestore_service.dart
@@ -75,11 +75,11 @@ class FirestoreService {
   }
 
   Future<void> replayPendingOperations() async {
-    final Box box = await _openBox(_pendingBoxName);
+    final Box<dynamic> box = await _openBox(_pendingBoxName);
     final List<PendingOp> ops = box.values
-        .whereType<Map>()
-        .map((dynamic value) =>
-            PendingOp.fromMap(Map<String, dynamic>.from(value as Map)))
+        .whereType<Map<dynamic, dynamic>>()
+        .map((Map<dynamic, dynamic> value) =>
+            PendingOp.fromMap(Map<String, dynamic>.from(value)))
         .toList()
       ..sort((PendingOp a, PendingOp b) => a.createdAt.compareTo(b.createdAt));
 
@@ -605,28 +605,28 @@ class FirestoreService {
     String boxName,
     T Function(Map<String, dynamic>) builder,
   ) async {
-    final Box box = await _openBox(boxName);
+    final Box<dynamic> box = await _openBox(boxName);
     final List<dynamic>? raw = box.get('data') as List<dynamic>?;
     if (raw == null) {
       return <T>[];
     }
     return raw
-        .whereType<Map>()
-        .map((dynamic entry) =>
-            builder(Map<String, dynamic>.from(entry as Map)))
+        .whereType<Map<dynamic, dynamic>>()
+        .map((Map<dynamic, dynamic> entry) =>
+            builder(Map<String, dynamic>.from(entry)))
         .toList();
   }
 
   Future<void> _cacheList(String boxName, List<Map<String, dynamic>> data) async {
-    final Box box = await _openBox(boxName);
+    final Box<dynamic> box = await _openBox(boxName);
     await box.put('data', data);
   }
 
-  Future<Box> _openBox(String name) async {
+  Future<Box<dynamic>> _openBox(String name) async {
     if (Hive.isBoxOpen(name)) {
-      return Hive.box(name);
+      return Hive.box<dynamic>(name);
     }
-    return Hive.openBox(name);
+    return Hive.openBox<dynamic>(name);
   }
 
   Future<List<T>> _decryptDocuments<T>({
@@ -726,12 +726,12 @@ class FirestoreService {
   }
 
   Future<void> _savePending(PendingOp op) async {
-    final Box box = await _openBox(_pendingBoxName);
+    final Box<dynamic> box = await _openBox(_pendingBoxName);
     await box.put(op.id, op.toMap());
   }
 
   Future<void> _removePending(String id) async {
-    final Box box = await _openBox(_pendingBoxName);
+    final Box<dynamic> box = await _openBox(_pendingBoxName);
     await box.delete(id);
   }
 
@@ -761,7 +761,6 @@ class FirestoreService {
       case MessageType.file:
         return '📎 Attachment';
       case MessageType.text:
-      default:
         return 'Message';
     }
   }

--- a/FamilyAppFlutter/lib/services/migration_service.dart
+++ b/FamilyAppFlutter/lib/services/migration_service.dart
@@ -113,7 +113,6 @@ class MigrationService {
       case legacy.MessageType.file:
         return MessageType.file;
       case legacy.MessageType.text:
-      default:
         return MessageType.text;
     }
   }

--- a/FamilyAppFlutter/lib/services/secure_storage_service.dart
+++ b/FamilyAppFlutter/lib/services/secure_storage_service.dart
@@ -9,8 +9,10 @@ class SecureStorageService {
       : _storage = storage ??
             const FlutterSecureStorage(
               aOptions: AndroidOptions(encryptedSharedPreferences: true),
-              iOptions: IOSOptions(accessibility: KeychainAccessibility.afterFirstUnlock),
-              mOptions: MacOsOptions(accessibility: KeychainAccessibility.afterFirstUnlock),
+              iOptions:
+                  IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+              mOptions:
+                  MacOsOptions(accessibility: KeychainAccessibility.first_unlock),
             );
 
   static const String _encKeyName = 'familyapp_e2ee_master_key_v1';

--- a/FamilyAppFlutter/macos/Podfile
+++ b/FamilyAppFlutter/macos/Podfile
@@ -3,6 +3,33 @@ platform :osx, '10.15'
 # Disable CocoaPods analytics
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
+require 'rubygems/version'
+
+# Удаляем устаревший lock-файл, если в нём зафиксирована старая версия Firebase.
+def ensure_minimum_pod_version(lock_path, pod_name, min_version)
+  return unless File.exist?(lock_path)
+
+  contents = File.read(lock_path)
+  version_match = contents.match(/#{Regexp.escape(pod_name)}[^0-9]*([0-9]+\.[0-9]+\.[0-9]+)/)
+  return unless version_match
+
+  begin
+    current_version = Gem::Version.new(version_match[1])
+    required_version = Gem::Version.new(min_version)
+  rescue ArgumentError
+    return
+  end
+
+  return unless current_version < required_version
+
+  File.delete(lock_path)
+  puts "Removed #{lock_path} to upgrade #{pod_name} from #{current_version} to >= #{required_version}."
+end
+
+firebase_min_version = '12.2.0'
+ensure_minimum_pod_version(File.join(__dir__, 'Podfile.lock'), 'Firebase/Firestore', firebase_min_version)
+ensure_minimum_pod_version(File.join(__dir__, 'Pods', 'Manifest.lock'), 'Firebase/Firestore', firebase_min_version)
+
 project 'Runner', {
   'Debug'   => :debug,
   'Profile' => :release,


### PR DESCRIPTION
## Summary
- update Hive box usage and Firestore persistence setup for the newer Firebase plugins
- restore FamilyData helper APIs and align call screens with Conversation.participantIds
- fix secure storage options and tighten Hive caching generics to satisfy analyzer
- rename local parsing helpers in model factories to clear the remaining analyzer lints

## Testing
- flutter analyze *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d25be85d0c832ba3c4be70f607fdcf