### PR TITLE
Rename parser helpers to satisfy analyzer

### DIFF
--- a/FamilyAppFlutter/lib/models/conversation.dart
+++ b/FamilyAppFlutter/lib/models/conversation.dart
@@ -36,7 +36,7 @@ class Conversation {
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -50,8 +50,8 @@ class Conversation {
       title: openData['title'] as String?,
       avatarUrl: openData['avatarUrl'] as String?,
       lastMessagePreview: openData['lastMessagePreview'] as String?,
-      createdAt: createdAt ?? _parseDate(openData['createdAt']),
-      updatedAt: updatedAt ?? _parseDate(openData['updatedAt']),
+      createdAt: createdAt ?? parseDate(openData['createdAt']),
+      updatedAt: updatedAt ?? parseDate(openData['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/models/event.dart
+++ b/FamilyAppFlutter/lib/models/event.dart
@@ -35,7 +35,7 @@ class Event {
       };
 
   static Event fromDecodableMap(Map<String, dynamic> map) {
-    DateTime _parseDate(dynamic value) {
+    DateTime parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value) ?? DateTime.now();
@@ -43,14 +43,14 @@ class Event {
       return DateTime.now();
     }
 
-    List<String> _parseList(dynamic value) {
+    List<String> parseList(dynamic value) {
       if (value is List) {
         return value.map((dynamic e) => e.toString()).toList();
       }
       return const <String>[];
     }
 
-    DateTime? _parseNullable(dynamic value) {
+    DateTime? parseNullable(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -61,12 +61,12 @@ class Event {
     return Event(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
-      startDateTime: _parseDate(map['startDateTime']),
-      endDateTime: _parseDate(map['endDateTime']),
+      startDateTime: parseDate(map['startDateTime']),
+      endDateTime: parseDate(map['endDateTime']),
       description: map['description'] as String?,
-      participantIds: _parseList(map['participantIds']),
-      createdAt: _parseNullable(map['createdAt']),
-      updatedAt: _parseNullable(map['updatedAt']),
+      participantIds: parseList(map['participantIds']),
+      createdAt: parseNullable(map['createdAt']),
+      updatedAt: parseNullable(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/family_member.dart
+++ b/FamilyAppFlutter/lib/models/family_member.dart
@@ -61,7 +61,7 @@ class FamilyMember {
       };
 
   static FamilyMember fromDecodableMap(Map<String, dynamic> map) {
-    List<Map<String, String>>? _mapList(dynamic value) {
+    List<Map<String, String>>? mapList(dynamic value) {
       if (value is List) {
         return value
             .whereType<Map>()
@@ -76,7 +76,7 @@ class FamilyMember {
       return null;
     }
 
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) {
         return value;
       }
@@ -90,7 +90,7 @@ class FamilyMember {
       id: (map['id'] ?? '').toString(),
       name: map['name'] as String?,
       relationship: map['relationship'] as String?,
-      birthday: _parseDate(map['birthday']),
+      birthday: parseDate(map['birthday']),
       phone: map['phone'] as String?,
       email: map['email'] as String?,
       avatarUrl: map['avatarUrl'] as String?,
@@ -98,11 +98,11 @@ class FamilyMember {
       socialMedia: map['socialMedia'] as String?,
       hobbies: map['hobbies'] as String?,
       documents: map['documents'] as String?,
-      documentsList: _mapList(map['documentsList']),
-      socialNetworks: _mapList(map['socialNetworks']),
-      messengers: _mapList(map['messengers']),
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      documentsList: mapList(map['documentsList']),
+      socialNetworks: mapList(map['socialNetworks']),
+      messengers: mapList(map['messengers']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/models/friend.dart
+++ b/FamilyAppFlutter/lib/models/friend.dart
@@ -29,7 +29,7 @@ class Friend {
       };
 
   static Friend fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -42,8 +42,8 @@ class Friend {
       name: map['name'] as String?,
       phone: map['phone'] as String?,
       notes: map['notes'] as String?,
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/gallery_item.dart
+++ b/FamilyAppFlutter/lib/models/gallery_item.dart
@@ -29,7 +29,7 @@ class GalleryItem {
       };
 
   static GalleryItem fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -42,8 +42,8 @@ class GalleryItem {
       url: map['url'] as String?,
       storagePath: map['storagePath'] as String?,
       caption: map['caption'] as String?,
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/message.dart
+++ b/FamilyAppFlutter/lib/models/message.dart
@@ -66,7 +66,7 @@ class Message {
     required String iv,
     required int encVersion,
   }) {
-    DateTime _parseDate(dynamic value) {
+    DateTime parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value) ?? DateTime.now();
@@ -74,7 +74,7 @@ class Message {
       return DateTime.now();
     }
 
-    DateTime? _parseNullable(dynamic value) {
+    DateTime? parseNullable(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -82,7 +82,7 @@ class Message {
       return null;
     }
 
-    MessageType _parseType(dynamic value) {
+    MessageType parseType(dynamic value) {
       final String name = value?.toString() ?? 'text';
       return MessageType.values.firstWhere(
         (MessageType type) => type.name == name,
@@ -90,7 +90,7 @@ class Message {
       );
     }
 
-    MessageStatus _parseStatus(dynamic value) {
+    MessageStatus parseStatus(dynamic value) {
       final String name = value?.toString() ?? 'sent';
       return MessageStatus.values.firstWhere(
         (MessageStatus status) => status.name == name,
@@ -98,8 +98,8 @@ class Message {
       );
     }
 
-    DateTime createdAt = _parseDate(metadata['createdAt']);
-    final DateTime? legacyCreated = _parseNullable(openData['createdAtLocal']);
+    DateTime createdAt = parseDate(metadata['createdAt']);
+    final DateTime? legacyCreated = parseNullable(openData['createdAtLocal']);
     if (legacyCreated != null) {
       createdAt = legacyCreated;
     }
@@ -107,13 +107,13 @@ class Message {
       id: id,
       conversationId: conversationId,
       senderId: metadata['senderId']?.toString() ?? '',
-      type: _parseType(metadata['type']),
+      type: parseType(metadata['type']),
       ciphertext: ciphertext,
       iv: iv,
       encVersion: encVersion,
       createdAt: createdAt,
-      editedAt: _parseNullable(metadata['editedAt']),
-      status: _parseStatus(metadata['status']),
+      editedAt: parseNullable(metadata['editedAt']),
+      status: parseStatus(metadata['status']),
       openData: openData,
     );
   }

--- a/FamilyAppFlutter/lib/models/schedule_item.dart
+++ b/FamilyAppFlutter/lib/models/schedule_item.dart
@@ -41,7 +41,7 @@ class ScheduleItem {
       };
 
   static ScheduleItem fromDecodableMap(Map<String, dynamic> map) {
-    DateTime _parseDate(dynamic value) {
+    DateTime parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value) ?? DateTime.now();
@@ -49,7 +49,7 @@ class ScheduleItem {
       return DateTime.now();
     }
 
-    Duration? _parseDuration(dynamic value) {
+    Duration? parseDuration(dynamic value) {
       if (value is int) return Duration(minutes: value);
       if (value is String && value.isNotEmpty) {
         final int? minutes = int.tryParse(value);
@@ -58,7 +58,7 @@ class ScheduleItem {
       return null;
     }
 
-    DateTime? _parseNullable(dynamic value) {
+    DateTime? parseNullable(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -69,13 +69,13 @@ class ScheduleItem {
     return ScheduleItem(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
-      dateTime: _parseDate(map['dateTime']),
-      duration: _parseDuration(map['duration']),
+      dateTime: parseDate(map['dateTime']),
+      duration: parseDuration(map['duration']),
       location: map['location'] as String?,
       notes: map['notes'] as String?,
       memberId: map['memberId'] as String?,
-      createdAt: _parseNullable(map['createdAt']),
-      updatedAt: _parseNullable(map['updatedAt']),
+      createdAt: parseNullable(map['createdAt']),
+      updatedAt: parseNullable(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/task.dart
+++ b/FamilyAppFlutter/lib/models/task.dart
@@ -40,7 +40,7 @@ class Task {
       };
 
   static Task fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? _parseDate(dynamic value) {
+    DateTime? parseDate(dynamic value) {
       if (value is DateTime) return value;
       if (value is String && value.isNotEmpty) {
         return DateTime.tryParse(value);
@@ -52,7 +52,7 @@ class Task {
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
       description: map['description'] as String?,
-      dueDate: _parseDate(map['dueDate']),
+      dueDate: parseDate(map['dueDate']),
       status: TaskStatus.values.firstWhere(
         (TaskStatus status) => status.name == map['status'],
         orElse: () => TaskStatus.todo,
@@ -61,8 +61,8 @@ class Task {
       points: map['points'] is int
           ? map['points'] as int
           : int.tryParse('${map['points']}'),
-      createdAt: _parseDate(map['createdAt']),
-      updatedAt: _parseDate(map['updatedAt']),
+      createdAt: parseDate(map['createdAt']),
+      updatedAt: parseDate(map['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/providers/family_data.dart
+++ b/FamilyAppFlutter/lib/providers/family_data.dart
@@ -18,6 +18,18 @@ class FamilyData extends ChangeNotifier {
   final List<Task> tasks = <Task>[];
   final List<Event> events = <Event>[];
 
+  FamilyMember? memberById(String? memberId) {
+    if (memberId == null) {
+      return null;
+    }
+    for (final FamilyMember member in members) {
+      if (member.id == memberId) {
+        return member;
+      }
+    }
+    return null;
+  }
+
   StreamSubscription<List<FamilyMember>>? _membersSub;
   StreamSubscription<List<Task>>? _tasksSub;
   StreamSubscription<List<Event>>? _eventsSub;


### PR DESCRIPTION
## Summary
- reintroduce the `memberById` helper on `FamilyData` so the chat screen and other widgets can resolve members by id
- rename local parser helpers across model factories to satisfy the analyzer's no_leading_underscores_for_local_identifiers lint

## Testing
- `flutter analyze` *(fails: Flutter SDK unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d25805e748832b9a18fa00ddaf092e