### PR TITLE
Add member lookup alias, static mapping helpers, and shared parsing utilities

### DIFF
--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
@@ -40,7 +39,7 @@ Future<void> main() async {
   await migrationService.migrateLegacyHiveData(AppConfig.familyId);
 
   final StorageService storageService = StorageService();
-  final Box settingsBox = await Hive.openBox('settings');
+  final Box<dynamic> settingsBox = await Hive.openBox<dynamic>('settings');
   final LanguageProvider languageProvider = LanguageProvider(box: settingsBox);
 
   runApp(

--- a/FamilyAppFlutter/lib/models/conversation.dart
+++ b/FamilyAppFlutter/lib/models/conversation.dart
@@ -1,3 +1,5 @@
+import 'package:family_app_flutter/utils/parsing.dart';
+
 class Conversation {
   const Conversation({
     required this.id,
@@ -36,22 +38,14 @@ class Conversation {
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
-    DateTime? parseDate(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
     return Conversation(
       id: id,
       participantIds: participantIds,
       title: openData['title'] as String?,
       avatarUrl: openData['avatarUrl'] as String?,
       lastMessagePreview: openData['lastMessagePreview'] as String?,
-      createdAt: createdAt ?? parseDate(openData['createdAt']),
-      updatedAt: updatedAt ?? parseDate(openData['updatedAt']),
+      createdAt: createdAt ?? parseNullableDateTime(openData['createdAt']),
+      updatedAt: updatedAt ?? parseNullableDateTime(openData['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/models/event.dart
+++ b/FamilyAppFlutter/lib/models/event.dart
@@ -1,3 +1,5 @@
+import 'package:family_app_flutter/utils/parsing.dart';
+
 class Event {
   const Event({
     required this.id,
@@ -35,38 +37,15 @@ class Event {
       };
 
   static Event fromDecodableMap(Map<String, dynamic> map) {
-    DateTime parseDate(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value) ?? DateTime.now();
-      }
-      return DateTime.now();
-    }
-
-    List<String> parseList(dynamic value) {
-      if (value is List) {
-        return value.map((dynamic e) => e.toString()).toList();
-      }
-      return const <String>[];
-    }
-
-    DateTime? parseNullable(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
     return Event(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
-      startDateTime: parseDate(map['startDateTime']),
-      endDateTime: parseDate(map['endDateTime']),
+      startDateTime: parseDateTimeOrNow(map['startDateTime']),
+      endDateTime: parseDateTimeOrNow(map['endDateTime']),
       description: map['description'] as String?,
-      participantIds: parseList(map['participantIds']),
-      createdAt: parseNullable(map['createdAt']),
-      updatedAt: parseNullable(map['updatedAt']),
+      participantIds: parseStringList(map['participantIds']),
+      createdAt: parseNullableDateTime(map['createdAt']),
+      updatedAt: parseNullableDateTime(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/family_member.dart
+++ b/FamilyAppFlutter/lib/models/family_member.dart
@@ -61,36 +61,11 @@ class FamilyMember {
       };
 
   static FamilyMember fromDecodableMap(Map<String, dynamic> map) {
-    List<Map<String, String>>? mapList(dynamic value) {
-      if (value is List) {
-        return value
-            .whereType<Map>()
-            .map((dynamic entry) => entry.map(
-                  (dynamic key, dynamic val) => MapEntry(
-                    key.toString(),
-                    val?.toString() ?? '',
-                  ),
-                ))
-            .toList();
-      }
-      return null;
-    }
-
-    DateTime? parseDate(dynamic value) {
-      if (value is DateTime) {
-        return value;
-      }
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
     return FamilyMember(
       id: (map['id'] ?? '').toString(),
       name: map['name'] as String?,
       relationship: map['relationship'] as String?,
-      birthday: parseDate(map['birthday']),
+      birthday: _parseDate(map['birthday']),
       phone: map['phone'] as String?,
       email: map['email'] as String?,
       avatarUrl: map['avatarUrl'] as String?,
@@ -98,12 +73,43 @@ class FamilyMember {
       socialMedia: map['socialMedia'] as String?,
       hobbies: map['hobbies'] as String?,
       documents: map['documents'] as String?,
-      documentsList: mapList(map['documentsList']),
-      socialNetworks: mapList(map['socialNetworks']),
-      messengers: mapList(map['messengers']),
-      createdAt: parseDate(map['createdAt']),
-      updatedAt: parseDate(map['updatedAt']),
+      documentsList: _mapList(map['documentsList']),
+      socialNetworks: _mapList(map['socialNetworks']),
+      messengers: _mapList(map['messengers']),
+      createdAt: _parseDate(map['createdAt']),
+      updatedAt: _parseDate(map['updatedAt']),
     );
+  }
+
+  static List<Map<String, String>>? _mapList(dynamic value) {
+    if (value is! List) {
+      return null;
+    }
+    final Iterable<Map<dynamic, dynamic>> entries =
+        value.whereType<Map<dynamic, dynamic>>();
+    if (entries.isEmpty) {
+      return <Map<String, String>>[];
+    }
+    return entries
+        .map(
+          (Map<dynamic, dynamic> entry) => entry.map<String, String>(
+            (dynamic key, dynamic val) => MapEntry<String, String>(
+              key.toString(),
+              val == null ? '' : val.toString(),
+            ),
+          ),
+        )
+        .toList();
+  }
+
+  static DateTime? _parseDate(dynamic value) {
+    if (value is DateTime) {
+      return value;
+    }
+    if (value is String && value.isNotEmpty) {
+      return DateTime.tryParse(value);
+    }
+    return null;
   }
 
   FamilyMember copyWith({

--- a/FamilyAppFlutter/lib/models/friend.dart
+++ b/FamilyAppFlutter/lib/models/friend.dart
@@ -1,3 +1,5 @@
+import 'package:family_app_flutter/utils/parsing.dart';
+
 class Friend {
   const Friend({
     required this.id,
@@ -29,21 +31,13 @@ class Friend {
       };
 
   static Friend fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? parseDate(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
     return Friend(
       id: (map['id'] ?? '').toString(),
       name: map['name'] as String?,
       phone: map['phone'] as String?,
       notes: map['notes'] as String?,
-      createdAt: parseDate(map['createdAt']),
-      updatedAt: parseDate(map['updatedAt']),
+      createdAt: parseNullableDateTime(map['createdAt']),
+      updatedAt: parseNullableDateTime(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/gallery_item.dart
+++ b/FamilyAppFlutter/lib/models/gallery_item.dart
@@ -1,3 +1,5 @@
+import 'package:family_app_flutter/utils/parsing.dart';
+
 class GalleryItem {
   const GalleryItem({
     required this.id,
@@ -29,21 +31,13 @@ class GalleryItem {
       };
 
   static GalleryItem fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? parseDate(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
     return GalleryItem(
       id: (map['id'] ?? '').toString(),
       url: map['url'] as String?,
       storagePath: map['storagePath'] as String?,
       caption: map['caption'] as String?,
-      createdAt: parseDate(map['createdAt']),
-      updatedAt: parseDate(map['updatedAt']),
+      createdAt: parseNullableDateTime(map['createdAt']),
+      updatedAt: parseNullableDateTime(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/message.dart
+++ b/FamilyAppFlutter/lib/models/message.dart
@@ -1,3 +1,5 @@
+import 'package:family_app_flutter/utils/parsing.dart';
+
 enum MessageType { text, image, file }
 
 enum MessageStatus { sending, sent, delivered, read }
@@ -66,40 +68,9 @@ class Message {
     required String iv,
     required int encVersion,
   }) {
-    DateTime parseDate(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value) ?? DateTime.now();
-      }
-      return DateTime.now();
-    }
-
-    DateTime? parseNullable(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
-    MessageType parseType(dynamic value) {
-      final String name = value?.toString() ?? 'text';
-      return MessageType.values.firstWhere(
-        (MessageType type) => type.name == name,
-        orElse: () => MessageType.text,
-      );
-    }
-
-    MessageStatus parseStatus(dynamic value) {
-      final String name = value?.toString() ?? 'sent';
-      return MessageStatus.values.firstWhere(
-        (MessageStatus status) => status.name == name,
-        orElse: () => MessageStatus.sent,
-      );
-    }
-
-    DateTime createdAt = parseDate(metadata['createdAt']);
-    final DateTime? legacyCreated = parseNullable(openData['createdAtLocal']);
+    DateTime createdAt = parseDateTimeOrNow(metadata['createdAt']);
+    final DateTime? legacyCreated =
+        parseNullableDateTime(openData['createdAtLocal']);
     if (legacyCreated != null) {
       createdAt = legacyCreated;
     }
@@ -107,13 +78,13 @@ class Message {
       id: id,
       conversationId: conversationId,
       senderId: metadata['senderId']?.toString() ?? '',
-      type: parseType(metadata['type']),
+      type: _parseType(metadata['type']),
       ciphertext: ciphertext,
       iv: iv,
       encVersion: encVersion,
       createdAt: createdAt,
-      editedAt: parseNullable(metadata['editedAt']),
-      status: parseStatus(metadata['status']),
+      editedAt: parseNullableDateTime(metadata['editedAt']),
+      status: _parseStatus(metadata['status']),
       openData: openData,
     );
   }
@@ -136,6 +107,44 @@ class Message {
           ? map['encVersion'] as int
           : int.tryParse('${map['encVersion']}') ?? 0,
     );
+  }
+
+  static MessageType _parseType(dynamic value) {
+    if (value is MessageType) {
+      return value;
+    }
+    final String? rawName = value?.toString();
+    if (rawName != null && rawName.isNotEmpty) {
+      final String normalized = rawName.contains('.')
+          ? rawName.substring(rawName.lastIndexOf('.') + 1)
+          : rawName;
+      final String lowerNormalized = normalized.toLowerCase();
+      for (final MessageType type in MessageType.values) {
+        if (type.name.toLowerCase() == lowerNormalized) {
+          return type;
+        }
+      }
+    }
+    return MessageType.text;
+  }
+
+  static MessageStatus _parseStatus(dynamic value) {
+    if (value is MessageStatus) {
+      return value;
+    }
+    final String? rawName = value?.toString();
+    if (rawName != null && rawName.isNotEmpty) {
+      final String normalized = rawName.contains('.')
+          ? rawName.substring(rawName.lastIndexOf('.') + 1)
+          : rawName;
+      final String lowerNormalized = normalized.toLowerCase();
+      for (final MessageStatus status in MessageStatus.values) {
+        if (status.name.toLowerCase() == lowerNormalized) {
+          return status;
+        }
+      }
+    }
+    return MessageStatus.sent;
   }
 
   Message copyWith({

--- a/FamilyAppFlutter/lib/models/schedule_item.dart
+++ b/FamilyAppFlutter/lib/models/schedule_item.dart
@@ -1,3 +1,5 @@
+import 'package:family_app_flutter/utils/parsing.dart';
+
 class ScheduleItem {
   const ScheduleItem({
     required this.id,
@@ -41,41 +43,16 @@ class ScheduleItem {
       };
 
   static ScheduleItem fromDecodableMap(Map<String, dynamic> map) {
-    DateTime parseDate(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value) ?? DateTime.now();
-      }
-      return DateTime.now();
-    }
-
-    Duration? parseDuration(dynamic value) {
-      if (value is int) return Duration(minutes: value);
-      if (value is String && value.isNotEmpty) {
-        final int? minutes = int.tryParse(value);
-        return minutes != null ? Duration(minutes: minutes) : null;
-      }
-      return null;
-    }
-
-    DateTime? parseNullable(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
     return ScheduleItem(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
-      dateTime: parseDate(map['dateTime']),
-      duration: parseDuration(map['duration']),
+      dateTime: parseDateTimeOrNow(map['dateTime']),
+      duration: parseDurationFromMinutes(map['duration']),
       location: map['location'] as String?,
       notes: map['notes'] as String?,
       memberId: map['memberId'] as String?,
-      createdAt: parseNullable(map['createdAt']),
-      updatedAt: parseNullable(map['updatedAt']),
+      createdAt: parseNullableDateTime(map['createdAt']),
+      updatedAt: parseNullableDateTime(map['updatedAt']),
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/task.dart
+++ b/FamilyAppFlutter/lib/models/task.dart
@@ -1,3 +1,5 @@
+import 'package:family_app_flutter/utils/parsing.dart';
+
 enum TaskStatus { todo, inProgress, done }
 
 class Task {
@@ -40,19 +42,11 @@ class Task {
       };
 
   static Task fromDecodableMap(Map<String, dynamic> map) {
-    DateTime? parseDate(dynamic value) {
-      if (value is DateTime) return value;
-      if (value is String && value.isNotEmpty) {
-        return DateTime.tryParse(value);
-      }
-      return null;
-    }
-
     return Task(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
       description: map['description'] as String?,
-      dueDate: parseDate(map['dueDate']),
+      dueDate: parseNullableDateTime(map['dueDate']),
       status: TaskStatus.values.firstWhere(
         (TaskStatus status) => status.name == map['status'],
         orElse: () => TaskStatus.todo,
@@ -61,8 +55,8 @@ class Task {
       points: map['points'] is int
           ? map['points'] as int
           : int.tryParse('${map['points']}'),
-      createdAt: parseDate(map['createdAt']),
-      updatedAt: parseDate(map['updatedAt']),
+      createdAt: parseNullableDateTime(map['createdAt']),
+      updatedAt: parseNullableDateTime(map['updatedAt']),
     );
   }
 

--- a/FamilyAppFlutter/lib/providers/family_data.dart
+++ b/FamilyAppFlutter/lib/providers/family_data.dart
@@ -18,7 +18,7 @@ class FamilyData extends ChangeNotifier {
   final List<Task> tasks = <Task>[];
   final List<Event> events = <Event>[];
 
-  FamilyMember? findMemberById(String? memberId) {
+  FamilyMember? memberById(String? memberId) {
     if (memberId == null) {
       return null;
     }
@@ -29,6 +29,8 @@ class FamilyData extends ChangeNotifier {
     }
     return null;
   }
+
+  FamilyMember? findMemberById(String? memberId) => memberById(memberId);
 
   StreamSubscription<List<FamilyMember>>? _membersSub;
   StreamSubscription<List<Task>>? _tasksSub;
@@ -111,6 +113,35 @@ class FamilyData extends ChangeNotifier {
     await _firestore.updateFamilyMember(familyId, member);
   }
 
+  Future<void> updateMemberDocuments(
+    String memberId, {
+    String? summary,
+    List<Map<String, String>>? documentsList,
+  }) async {
+    final int index = members.indexWhere((FamilyMember m) => m.id == memberId);
+    if (index == -1) {
+      return;
+    }
+    final FamilyMember updated = members[index].copyWith(
+      documents: summary,
+      documentsList: documentsList,
+    );
+    members[index] = updated;
+    notifyListeners();
+    await _firestore.updateFamilyMember(familyId, updated);
+  }
+
+  Future<void> updateMemberHobbies(String memberId, String? hobbies) async {
+    final int index = members.indexWhere((FamilyMember m) => m.id == memberId);
+    if (index == -1) {
+      return;
+    }
+    final FamilyMember updated = members[index].copyWith(hobbies: hobbies);
+    members[index] = updated;
+    notifyListeners();
+    await _firestore.updateFamilyMember(familyId, updated);
+  }
+
   Future<void> removeMember(FamilyMember member) async {
     members.removeWhere((FamilyMember m) => m.id == member.id);
     notifyListeners();
@@ -130,6 +161,20 @@ class FamilyData extends ChangeNotifier {
       notifyListeners();
     }
     await _firestore.updateTask(familyId, task);
+  }
+
+  Future<void> updateTaskStatus(String taskId, TaskStatus status) async {
+    final int index = tasks.indexWhere((Task task) => task.id == taskId);
+    if (index == -1) {
+      return;
+    }
+    final Task updated = tasks[index].copyWith(status: status);
+    tasks[index] = updated;
+    tasks.sort((Task a, Task b) =>
+        (a.dueDate ?? DateTime.fromMillisecondsSinceEpoch(0))
+            .compareTo(b.dueDate ?? DateTime.fromMillisecondsSinceEpoch(0)));
+    notifyListeners();
+    await _firestore.updateTask(familyId, updated);
   }
 
   Future<void> removeTask(String id) async {

--- a/FamilyAppFlutter/lib/screens/call_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_screen.dart
@@ -20,7 +20,7 @@ class CallScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final familyData = Provider.of<FamilyData>(context, listen: false);
-    final participants = conversation.memberIds
+    final participants = conversation.participantIds
         .map((id) => familyData.members.firstWhere(
               (member) => member.id == id,
               orElse: () => FamilyMember(

--- a/FamilyAppFlutter/lib/screens/call_setup_screen.dart
+++ b/FamilyAppFlutter/lib/screens/call_setup_screen.dart
@@ -49,7 +49,7 @@ class _CallSetupScreenState extends State<CallSetupScreen> {
     final conversation = Conversation(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       title: title,
-      memberIds: selected,
+      participantIds: selected,
       createdAt: DateTime.now(),
     );
     Navigator.of(context).push(

--- a/FamilyAppFlutter/lib/screens/friends_screen.dart
+++ b/FamilyAppFlutter/lib/screens/friends_screen.dart
@@ -33,10 +33,7 @@ class FriendsScreen extends StatelessWidget {
                 trailing: IconButton(
                   icon: const Icon(Icons.delete_outline),
                   onPressed: () async {
-                    final id = friend.id;
-                    if (id != null) {
-                      await context.read<FriendsData>().removeFriend(id);
-                    }
+                    await context.read<FriendsData>().removeFriend(friend.id);
                   },
                   tooltip: context.tr('deleteAction'),
                 ),

--- a/FamilyAppFlutter/lib/screens/gallery_screen.dart
+++ b/FamilyAppFlutter/lib/screens/gallery_screen.dart
@@ -57,8 +57,9 @@ class GalleryScreen extends StatelessWidget {
 
                         child: IconButton(
                           onPressed: () async {
-                            final id = item.id ?? item.url ?? '';
-                            await context.read<GalleryData>().removeItem(id);
+                            await context
+                                .read<GalleryData>()
+                                .removeItem(item.id);
                           },
                           icon: const Icon(Icons.delete, size: 18),
                           tooltip: context.tr('deleteAction'),

--- a/FamilyAppFlutter/lib/services/firebase_service.dart
+++ b/FamilyAppFlutter/lib/services/firebase_service.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/foundation.dart';
 
 import '../firebase_options.dart';
 
@@ -31,19 +30,18 @@ class FirebaseService {
 
     final FirebaseFirestore firestore = FirebaseFirestore.instance;
 
-    if (kIsWeb) {
-      try {
-        await firestore.enablePersistence(
-          const PersistenceSettings(synchronizeTabs: true),
-        );
-      } on FirebaseException {
-        // On some browsers persistence may already be enabled or unsupported.
-      }
-    } else {
-      firestore.settings = const Settings(
-        persistenceEnabled: true,
-        cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
-      );
+    final Settings currentSettings = firestore.settings;
+    final Settings updatedSettings = currentSettings.copyWith(
+      persistenceEnabled: true,
+      cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+    );
+
+    try {
+      firestore.settings = updatedSettings;
+    } on FirebaseException {
+      // Some platforms (e.g. certain web browsers) may not support persistence
+      // or might already have it configured. Swallowing the exception keeps
+      // initialization resilient while still enabling persistence elsewhere.
     }
 
     _initialized = true;

--- a/FamilyAppFlutter/lib/services/firestore_service.dart
+++ b/FamilyAppFlutter/lib/services/firestore_service.dart
@@ -75,11 +75,11 @@ class FirestoreService {
   }
 
   Future<void> replayPendingOperations() async {
-    final Box box = await _openBox(_pendingBoxName);
+    final Box<dynamic> box = await _openBox(_pendingBoxName);
     final List<PendingOp> ops = box.values
-        .whereType<Map>()
-        .map((dynamic value) =>
-            PendingOp.fromMap(Map<String, dynamic>.from(value as Map)))
+        .whereType<Map<dynamic, dynamic>>()
+        .map((Map<dynamic, dynamic> value) =>
+            PendingOp.fromMap(Map<String, dynamic>.from(value)))
         .toList()
       ..sort((PendingOp a, PendingOp b) => a.createdAt.compareTo(b.createdAt));
 
@@ -605,28 +605,28 @@ class FirestoreService {
     String boxName,
     T Function(Map<String, dynamic>) builder,
   ) async {
-    final Box box = await _openBox(boxName);
+    final Box<dynamic> box = await _openBox(boxName);
     final List<dynamic>? raw = box.get('data') as List<dynamic>?;
     if (raw == null) {
       return <T>[];
     }
     return raw
-        .whereType<Map>()
-        .map((dynamic entry) =>
-            builder(Map<String, dynamic>.from(entry as Map)))
+        .whereType<Map<dynamic, dynamic>>()
+        .map((Map<dynamic, dynamic> entry) =>
+            builder(Map<String, dynamic>.from(entry)))
         .toList();
   }
 
   Future<void> _cacheList(String boxName, List<Map<String, dynamic>> data) async {
-    final Box box = await _openBox(boxName);
+    final Box<dynamic> box = await _openBox(boxName);
     await box.put('data', data);
   }
 
-  Future<Box> _openBox(String name) async {
+  Future<Box<dynamic>> _openBox(String name) async {
     if (Hive.isBoxOpen(name)) {
-      return Hive.box(name);
+      return Hive.box<dynamic>(name);
     }
-    return Hive.openBox(name);
+    return Hive.openBox<dynamic>(name);
   }
 
   Future<List<T>> _decryptDocuments<T>({
@@ -726,12 +726,12 @@ class FirestoreService {
   }
 
   Future<void> _savePending(PendingOp op) async {
-    final Box box = await _openBox(_pendingBoxName);
+    final Box<dynamic> box = await _openBox(_pendingBoxName);
     await box.put(op.id, op.toMap());
   }
 
   Future<void> _removePending(String id) async {
-    final Box box = await _openBox(_pendingBoxName);
+    final Box<dynamic> box = await _openBox(_pendingBoxName);
     await box.delete(id);
   }
 
@@ -761,7 +761,6 @@ class FirestoreService {
       case MessageType.file:
         return '📎 Attachment';
       case MessageType.text:
-      default:
         return 'Message';
     }
   }

--- a/FamilyAppFlutter/lib/services/migration_service.dart
+++ b/FamilyAppFlutter/lib/services/migration_service.dart
@@ -113,7 +113,6 @@ class MigrationService {
       case legacy.MessageType.file:
         return MessageType.file;
       case legacy.MessageType.text:
-      default:
         return MessageType.text;
     }
   }

--- a/FamilyAppFlutter/lib/services/secure_storage_service.dart
+++ b/FamilyAppFlutter/lib/services/secure_storage_service.dart
@@ -9,8 +9,12 @@ class SecureStorageService {
       : _storage = storage ??
             const FlutterSecureStorage(
               aOptions: AndroidOptions(encryptedSharedPreferences: true),
-              iOptions: IOSOptions(accessibility: KeychainAccessibility.afterFirstUnlock),
-              mOptions: MacOsOptions(accessibility: KeychainAccessibility.afterFirstUnlock),
+              iOptions: IOSOptions(
+                accessibility: KeychainAccessibility.first_unlock,
+              ),
+              mOptions: MacOsOptions(
+                accessibility: KeychainAccessibility.first_unlock,
+              ),
             );
 
   static const String _encKeyName = 'familyapp_e2ee_master_key_v1';

--- a/FamilyAppFlutter/lib/utils/parsing.dart
+++ b/FamilyAppFlutter/lib/utils/parsing.dart
@@ -1,0 +1,35 @@
+/// Helpers for converting loosely typed persistence layer values into the
+/// strongly typed models used throughout the app.
+DateTime? parseNullableDateTime(dynamic value) {
+  if (value is DateTime) {
+    return value;
+  }
+  if (value is String && value.isNotEmpty) {
+    return DateTime.tryParse(value);
+  }
+  return null;
+}
+
+DateTime parseDateTimeOrNow(dynamic value) {
+  return parseNullableDateTime(value) ?? DateTime.now();
+}
+
+List<String> parseStringList(dynamic value) {
+  if (value is List) {
+    return value.map((dynamic element) => element.toString()).toList();
+  }
+  return const <String>[];
+}
+
+Duration? parseDurationFromMinutes(dynamic value) {
+  if (value is int) {
+    return Duration(minutes: value);
+  }
+  if (value is String && value.isNotEmpty) {
+    final int? minutes = int.tryParse(value);
+    if (minutes != null) {
+      return Duration(minutes: minutes);
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- convert `FamilyMember.fromDecodableMap` to reuse static helpers for typed list conversion and date parsing so analyzer references resolve cleanly
- expose `FamilyData.memberById` while keeping the old `findMemberById` alias so existing UI lookups compile without analyzer errors
- centralize date, list, and duration parsing in `utils/parsing.dart` and update models to use the shared helpers to satisfy the no-leading-underscore lint
- add static enum parsing helpers to `Message` so analyzer warnings about unused local functions and missing methods are resolved

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d278b9c1d8832b96a97506f25faf48