### PR TITLE
Refactor data models and Firestore integration

### DIFF
--- a/FamilyAppFlutter/lib/models/chat.dart
+++ b/FamilyAppFlutter/lib/models/chat.dart
@@ -1,42 +1,53 @@
+import '../utils/parsing.dart';
 import 'package:hive/hive.dart';
 
 part 'chat.g.dart';
 
-/// A conversation between two or more family members.  Chats hold
-/// metadata such as the title, participating member identifiers, last
-/// updated timestamp and a preview of the most recent message.  The
-/// contents of the messages themselves are stored separately.
+/// A conversation between two or more family members stored locally for quick
+/// access. The encrypted payload lives in Firestore, while this model keeps
+/// metadata such as the title and last message preview.
 @HiveType(typeId: 11)
-class Chat extends HiveObject {
-  /// Unique identifier for this chat.
-  @HiveField(0)
-  String id;
-
-  /// User-provided title of the chat (e.g. "Family group").
-  @HiveField(1)
-  String title;
-
-  /// List of member identifiers participating in this chat.
-  @HiveField(2)
-  List<String> memberIds;
-
-  /// Timestamp of the last activity in this chat.
-  @HiveField(3)
-  DateTime updatedAt;
-
-  /// Optional preview of the most recent message sent in this chat.
-  @HiveField(4)
-  String? lastMessagePreview;
-
-  Chat({
+class Chat {
+  const Chat({
     required this.id,
     required this.title,
-    required this.memberIds,
+    required List<String> memberIds,
     required this.updatedAt,
     this.lastMessagePreview,
-  });
+  }) : memberIds = List.unmodifiable(memberIds);
 
-  Map<String, dynamic> toMap() => {
+  /// Unique identifier for this chat.
+  @HiveField(0)
+  final String id;
+
+  /// Human friendly title for the chat.
+  @HiveField(1)
+  final String title;
+
+  /// Participants of the chat.
+  @HiveField(2)
+  final List<String> memberIds;
+
+  /// Timestamp of the most recent message or metadata change.
+  @HiveField(3)
+  final DateTime updatedAt;
+
+  /// Optional preview text for the last message.
+  @HiveField(4)
+  final String? lastMessagePreview;
+
+  factory Chat.fromMap(Map<String, dynamic> map) => Chat(
+        id: (map['id'] ?? '').toString(),
+        title: (map['title'] ?? '').toString(),
+        memberIds: (map['memberIds'] as List?)
+                ?.map((dynamic e) => e.toString())
+                .toList() ??
+            const <String>[],
+        updatedAt: parseDateTimeOrNow(map['updatedAt']),
+        lastMessagePreview: map['lastMessagePreview'] as String?,
+      );
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
         'id': id,
         'title': title,
         'memberIds': memberIds,
@@ -44,16 +55,18 @@ class Chat extends HiveObject {
         'lastMessagePreview': lastMessagePreview,
       };
 
-  static Chat fromMap(Map<String, dynamic> map) => Chat(
-        id: (map['id'] ?? '').toString(),
-        title: (map['title'] ?? '').toString(),
-        memberIds: (map['memberIds'] as List?)
-                ?.map((dynamic e) => e.toString())
-                .toList() ??
-            <String>[],
-        updatedAt: map['updatedAt'] is String
-            ? DateTime.tryParse(map['updatedAt']) ?? DateTime.now()
-            : DateTime.now(),
-        lastMessagePreview: map['lastMessagePreview'] as String?,
-      );
+  Chat copyWith({
+    String? title,
+    List<String>? memberIds,
+    DateTime? updatedAt,
+    String? lastMessagePreview,
+  }) {
+    return Chat(
+      id: id,
+      title: title ?? this.title,
+      memberIds: memberIds ?? this.memberIds,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lastMessagePreview: lastMessagePreview ?? this.lastMessagePreview,
+    );
+  }
 }

--- a/FamilyAppFlutter/lib/models/chat_message.dart
+++ b/FamilyAppFlutter/lib/models/chat_message.dart
@@ -1,59 +1,16 @@
+import 'message_type.dart';
+import '../utils/parsing.dart';
 import 'package:hive/hive.dart';
 
 part 'chat_message.g.dart';
 
-/// Types of messages that can be sent in a chat.  Text messages
-/// contain plain text, image messages reference a local file path, and
-/// file messages reference any other kind of file path.
-@HiveType(typeId: 21)
-enum MessageType {
-  @HiveField(0)
-  text,
-  @HiveField(1)
-  image,
-  @HiveField(2)
-  file,
-}
-
-/// Represents an individual message within a chat.  A message has an
-/// associated sender, belongs to a particular chat, and may be
-/// marked as read.  Attachments are stored as the content for
-/// non‑text messages.
+/// Represents an individual message within a chat. Attachments are stored as
+/// URLs in [content] while metadata is encrypted remotely.
 @HiveType(typeId: 20)
-class ChatMessage extends HiveObject {
-  /// Unique identifier for this message.
-  @HiveField(0)
-  String id;
+class ChatMessage {
+  static const Object _sentinel = Object();
 
-  /// Identifier of the chat this message belongs to.
-  @HiveField(1)
-  String chatId;
-
-  /// Identifier of the member who sent the message.
-  @HiveField(2)
-  String senderId;
-
-  /// The message text or file path, depending on the type.
-  @HiveField(3)
-  String content;
-
-  /// When the message was created.
-  @HiveField(4)
-  DateTime createdAt;
-
-  /// The type of message (text, image, or file).
-  @HiveField(5)
-  MessageType type;
-
-  /// Whether the message has been read by the recipient.
-  @HiveField(6)
-  bool isRead;
-
-  /// Optional storage path of the attachment (if any).
-  @HiveField(7)
-  String? storagePath;
-
-  ChatMessage({
+  const ChatMessage({
     required this.id,
     required this.chatId,
     required this.senderId,
@@ -64,7 +21,52 @@ class ChatMessage extends HiveObject {
     this.storagePath,
   });
 
-  Map<String, dynamic> toMap() => {
+  /// Unique identifier for this message.
+  @HiveField(0)
+  final String id;
+
+  /// Identifier of the chat this message belongs to.
+  @HiveField(1)
+  final String chatId;
+
+  /// Identifier of the member who sent the message.
+  @HiveField(2)
+  final String senderId;
+
+  /// The message text or file URL depending on the [type].
+  @HiveField(3)
+  final String content;
+
+  /// When the message was created.
+  @HiveField(4)
+  final DateTime createdAt;
+
+  /// The type of message (text, image, or file).
+  @HiveField(5)
+  final MessageType type;
+
+  /// Whether the message has been read by the recipient.
+  @HiveField(6)
+  final bool isRead;
+
+  /// Optional storage path of the attachment (if any).
+  @HiveField(7)
+  final String? storagePath;
+
+  factory ChatMessage.fromMap(Map<String, dynamic> map) => ChatMessage(
+        id: (map['id'] ?? '').toString(),
+        chatId: (map['chatId'] ?? '').toString(),
+        senderId: (map['senderId'] ?? '').toString(),
+        content: (map['content'] ?? '').toString(),
+        createdAt: parseDateTimeOrNow(map['createdAt']),
+        type: _messageTypeFromString(map['type']),
+        isRead: map['isRead'] is bool
+            ? map['isRead'] as bool
+            : (map['isRead']?.toString().toLowerCase() == 'true'),
+        storagePath: map['storagePath'] as String?,
+      );
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
         'id': id,
         'chatId': chatId,
         'senderId': senderId,
@@ -75,30 +77,42 @@ class ChatMessage extends HiveObject {
         'storagePath': storagePath,
       };
 
-  static ChatMessage fromMap(Map<String, dynamic> map) => ChatMessage(
-        id: (map['id'] ?? '').toString(),
-        chatId: (map['chatId'] ?? '').toString(),
-        senderId: (map['senderId'] ?? '').toString(),
-        content: (map['content'] ?? '').toString(),
-        createdAt: map['createdAt'] is String
-            ? DateTime.tryParse(map['createdAt']) ?? DateTime.now()
-            : DateTime.now(),
-        type: _messageTypeFromString(map['type']),
-        isRead: map['isRead'] is bool
-            ? map['isRead'] as bool
-            : (map['isRead']?.toString().toLowerCase() == 'true'),
-        storagePath: map['storagePath'] as String?,
-      );
+  ChatMessage copyWith({
+    Object? content = _sentinel,
+    Object? createdAt = _sentinel,
+    Object? type = _sentinel,
+    Object? isRead = _sentinel,
+    Object? storagePath = _sentinel,
+  }) {
+    return ChatMessage(
+      id: id,
+      chatId: chatId,
+      senderId: senderId,
+      content: content == _sentinel ? this.content : content as String,
+      createdAt: createdAt == _sentinel
+          ? this.createdAt
+          : createdAt as DateTime,
+      type: type == _sentinel ? this.type : type as MessageType,
+      isRead: isRead == _sentinel ? this.isRead : isRead as bool,
+      storagePath:
+          storagePath == _sentinel ? this.storagePath : storagePath as String?,
+    );
+  }
 
   static MessageType _messageTypeFromString(dynamic value) {
-    final name = value?.toString();
-    switch (name) {
-      case 'image':
-        return MessageType.image;
-      case 'file':
-        return MessageType.file;
-      default:
-        return MessageType.text;
+    if (value is MessageType) {
+      return value;
     }
+    final String? name = value?.toString();
+    if (name == null || name.isEmpty) {
+      return MessageType.text;
+    }
+    final String lower = name.toLowerCase();
+    for (final MessageType type in MessageType.values) {
+      if (type.name.toLowerCase() == lower) {
+        return type;
+      }
+    }
+    return MessageType.text;
   }
 }

--- a/FamilyAppFlutter/lib/models/conversation.dart
+++ b/FamilyAppFlutter/lib/models/conversation.dart
@@ -1,75 +1,90 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import '../utils/parsing.dart';
 
+/// Represents a realtime call or chat conversation between family members.
+/// The model keeps only high level metadata while the encrypted payload of
+/// individual messages is stored separately in Firestore.
 class Conversation {
-  final String id;
-  final String title;
-  final List<String> memberIds;
-  final DateTime? createdAt;
-  final DateTime? lastMessageTime;
-
   Conversation({
     required this.id,
     required this.title,
-    required this.memberIds,
-    this.createdAt,
+    required List<String> participantIds,
+    required this.createdAt,
+    this.updatedAt,
     this.lastMessageTime,
-  });
+    this.avatarUrl,
+    this.lastMessagePreview,
+  }) : participantIds = List.unmodifiable(participantIds);
 
-
+  /// Unique identifier of the conversation document in Firestore.
   final String id;
+
+  /// Human friendly title that is shown to the users.
+  final String title;
+
+  /// Identifiers of members participating in this conversation.
   final List<String> participantIds;
-  final String? title;
-  final String? avatarUrl;
-  final String? lastMessagePreview;
-  final DateTime? createdAt;
+
+  /// When the conversation was created.
+  final DateTime createdAt;
+
+  /// Timestamp of the last update (e.g. message sent or metadata change).
   final DateTime? updatedAt;
 
-  List<String> get memberIds => participantIds;
+  /// Timestamp of the latest message if available.
+  final DateTime? lastMessageTime;
 
-  Map<String, dynamic> toEncodableMap() => <String, dynamic>{
+  /// Optional URL of the conversation avatar.
+  final String? avatarUrl;
+
+  /// Preview text of the last message used in lists.
+  final String? lastMessagePreview;
+
+  /// Creates a [Conversation] from a Firestore map. Non existing optional
+  /// fields gracefully fall back to sensible defaults.
+  factory Conversation.fromMap(Map<String, dynamic> map) {
+    return Conversation(
+      id: (map['id'] ?? '').toString(),
+      title: (map['title'] ?? '').toString(),
+      participantIds: parseStringList(map['participantIds']),
+      createdAt: parseDateTimeOrNow(map['createdAt']),
+      updatedAt: parseNullableDateTime(map['updatedAt']),
+      lastMessageTime: parseNullableDateTime(map['lastMessageTime']),
+      avatarUrl: map['avatarUrl'] as String?,
+      lastMessagePreview: map['lastMessagePreview'] as String?,
+    );
+  }
+
+  /// Serialises the conversation to a JSON compatible map.
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
         'title': title,
-        'memberIds': memberIds,
-        'createdAt': createdAt?.toIso8601String(),
+        'participantIds': participantIds,
+        'createdAt': createdAt.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
         'lastMessageTime': lastMessageTime?.toIso8601String(),
+        'avatarUrl': avatarUrl,
+        'lastMessagePreview': lastMessagePreview,
       };
 
-  static Conversation fromDecodableMap(
-    Map<String, dynamic> openData, {
-    required String id,
-    required List<String> participantIds,
+  /// Returns a copy of this conversation with the provided fields replaced.
+  Conversation copyWith({
+    String? title,
+    List<String>? participantIds,
     DateTime? createdAt,
     DateTime? updatedAt,
-  }) {
-
-    return Conversation(
-      id: id,
-      participantIds: participantIds,
-      title: openData['title'] as String?,
-      avatarUrl: openData['avatarUrl'] as String?,
-      lastMessagePreview: openData['lastMessagePreview'] as String?,
-      createdAt: createdAt ?? parseNullableDateTime(openData['createdAt']),
-      updatedAt: updatedAt ?? parseNullableDateTime(openData['updatedAt']),
-
-    );
-  }
-
-  Conversation copyWith({
-    List<String>? participantIds,
-    String? title,
+    DateTime? lastMessageTime,
     String? avatarUrl,
     String? lastMessagePreview,
-    DateTime? createdAt,
-    DateTime? updatedAt,
   }) {
     return Conversation(
       id: id,
-      participantIds: participantIds ?? this.participantIds,
       title: title ?? this.title,
-      avatarUrl: avatarUrl ?? this.avatarUrl,
-      lastMessagePreview: lastMessagePreview ?? this.lastMessagePreview,
+      participantIds: participantIds ?? this.participantIds,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      lastMessageTime: lastMessageTime ?? this.lastMessageTime,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      lastMessagePreview: lastMessagePreview ?? this.lastMessagePreview,
     );
   }
-
 }

--- a/FamilyAppFlutter/lib/models/event.dart
+++ b/FamilyAppFlutter/lib/models/event.dart
@@ -1,43 +1,30 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import '../utils/parsing.dart';
 
+/// Calendar event shared between family members.
 class Event {
-  final String id;
-  final String title;
-  final DateTime startDateTime;
-  final DateTime endDateTime;
-  final String? description;
-  final List<String> participantIds;
-  final DateTime updatedAt;
+  static const Object _sentinel = Object();
 
-  Event({
+  const Event({
     required this.id,
     required this.title,
     required this.startDateTime,
     required this.endDateTime,
     this.description,
     List<String>? participantIds,
-    DateTime? updatedAt,
-  })  : participantIds = participantIds ?? const [],
-        updatedAt = updatedAt ?? DateTime.now();
+    this.createdAt,
+    this.updatedAt,
+  }) : participantIds = List.unmodifiable(participantIds ?? const <String>[]);
 
-  Map<String, dynamic> toMap() => {
-        'id': id,
-        'title': title,
-        'startDateTime': startDateTime.toIso8601String(),
-        'endDateTime': endDateTime.toIso8601String(),
-        'description': description,
-        'participantIds': participantIds,
-        'updatedAt': updatedAt.toIso8601String(),
-      };
+  final String id;
+  final String title;
+  final DateTime startDateTime;
+  final DateTime endDateTime;
+  final String? description;
+  final List<String> participantIds;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
 
-  Map<String, dynamic> toLocalMap() => <String, dynamic>{
-        'id': id,
-        ...toEncodableMap(),
-        'createdAt': createdAt?.toIso8601String(),
-        'updatedAt': updatedAt?.toIso8601String(),
-      };
-
-  static Event fromDecodableMap(Map<String, dynamic> map) {
+  factory Event.fromMap(Map<String, dynamic> map) {
     return Event(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
@@ -47,7 +34,45 @@ class Event {
       participantIds: parseStringList(map['participantIds']),
       createdAt: parseNullableDateTime(map['createdAt']),
       updatedAt: parseNullableDateTime(map['updatedAt']),
+    );
+  }
 
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
+        'title': title,
+        'startDateTime': startDateTime.toIso8601String(),
+        'endDateTime': endDateTime.toIso8601String(),
+        'description': description,
+        'participantIds': participantIds,
+        'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
+      };
+
+  Event copyWith({
+    Object? title = _sentinel,
+    Object? startDateTime = _sentinel,
+    Object? endDateTime = _sentinel,
+    Object? description = _sentinel,
+    List<String>? participantIds,
+    Object? createdAt = _sentinel,
+    Object? updatedAt = _sentinel,
+  }) {
+    return Event(
+      id: id,
+      title: title == _sentinel ? this.title : title as String,
+      startDateTime: startDateTime == _sentinel
+          ? this.startDateTime
+          : startDateTime as DateTime,
+      endDateTime:
+          endDateTime == _sentinel ? this.endDateTime : endDateTime as DateTime,
+      description: description == _sentinel
+          ? this.description
+          : description as String?,
+      participantIds: participantIds ?? this.participantIds,
+      createdAt:
+          createdAt == _sentinel ? this.createdAt : createdAt as DateTime?,
+      updatedAt:
+          updatedAt == _sentinel ? this.updatedAt : updatedAt as DateTime?,
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/family_member.dart
+++ b/FamilyAppFlutter/lib/models/family_member.dart
@@ -1,7 +1,28 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import '../utils/parsing.dart';
 
+/// Represents a member of the family with optional contact information,
+/// hobbies and custom metadata.
 class FamilyMember {
-  static const _sentinel = Object();
+  static const Object _sentinel = Object();
+
+  const FamilyMember({
+    required this.id,
+    this.name,
+    this.relationship,
+    this.birthday,
+    this.phone,
+    this.email,
+    this.avatarUrl,
+    this.avatarStoragePath,
+    this.socialMedia,
+    this.hobbies,
+    this.documents,
+    this.documentsList,
+    this.socialNetworks,
+    this.messengers,
+    this.createdAt,
+    this.updatedAt,
+  });
 
   final String id;
   final String? name;
@@ -17,50 +38,10 @@ class FamilyMember {
   final List<Map<String, String>>? documentsList;
   final List<Map<String, String>>? socialNetworks;
   final List<Map<String, String>>? messengers;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
 
-  FamilyMember({
-    required this.id,
-    this.name,
-    this.relationship,
-    this.birthday,
-    this.phone,
-    this.email,
-    this.avatarUrl,
-    this.avatarStoragePath,
-    this.socialMedia,
-    this.hobbies,
-    this.documents,
-    this.documentsList,
-    this.socialNetworks,
-    this.messengers,
-  });
-
-  Map<String, dynamic> toMap() => {
-        'id': id,
-        'name': name,
-        'relationship': relationship,
-        'birthday': birthday?.toIso8601String(),
-        'phone': phone,
-        'email': email,
-        'avatarUrl': avatarUrl,
-        'avatarStoragePath': avatarStoragePath,
-        'socialMedia': socialMedia,
-        'hobbies': hobbies,
-        'documents': documents,
-        'documentsList': documentsList,
-        'socialNetworks': socialNetworks,
-        'messengers': messengers,
-      };
-
-  Map<String, dynamic> toLocalMap() => <String, dynamic>{
-        'id': id,
-        ...toEncodableMap(),
-        'createdAt': createdAt?.toIso8601String(),
-        'updatedAt': updatedAt?.toIso8601String(),
-      };
-
-  static FamilyMember fromDecodableMap(Map<String, dynamic> map) {
-
+  factory FamilyMember.fromMap(Map<String, dynamic> map) {
     return FamilyMember(
       id: (map['id'] ?? '').toString(),
       name: map['name'] as String?,
@@ -78,9 +59,27 @@ class FamilyMember {
       messengers: parseStringMapList(map['messengers']),
       createdAt: parseNullableDateTime(map['createdAt']),
       updatedAt: parseNullableDateTime(map['updatedAt']),
-
     );
   }
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
+        'name': name,
+        'relationship': relationship,
+        'birthday': birthday?.toIso8601String(),
+        'phone': phone,
+        'email': email,
+        'avatarUrl': avatarUrl,
+        'avatarStoragePath': avatarStoragePath,
+        'socialMedia': socialMedia,
+        'hobbies': hobbies,
+        'documents': documents,
+        'documentsList': documentsList,
+        'socialNetworks': socialNetworks,
+        'messengers': messengers,
+        'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
+      };
 
   FamilyMember copyWith({
     Object? name = _sentinel,
@@ -96,23 +95,24 @@ class FamilyMember {
     Object? documentsList = _sentinel,
     Object? socialNetworks = _sentinel,
     Object? messengers = _sentinel,
+    Object? createdAt = _sentinel,
+    Object? updatedAt = _sentinel,
   }) {
     return FamilyMember(
       id: id,
       name: name == _sentinel ? this.name : name as String?,
-      relationship:
-          relationship == _sentinel ? this.relationship : relationship as String?,
+      relationship: relationship == _sentinel
+          ? this.relationship
+          : relationship as String?,
       birthday: birthday == _sentinel ? this.birthday : birthday as DateTime?,
       phone: phone == _sentinel ? this.phone : phone as String?,
       email: email == _sentinel ? this.email : email as String?,
-      avatarUrl:
-          avatarUrl == _sentinel ? this.avatarUrl : avatarUrl as String?,
+      avatarUrl: avatarUrl == _sentinel ? this.avatarUrl : avatarUrl as String?,
       avatarStoragePath: avatarStoragePath == _sentinel
           ? this.avatarStoragePath
           : avatarStoragePath as String?,
-      socialMedia: socialMedia == _sentinel
-          ? this.socialMedia
-          : socialMedia as String?,
+      socialMedia:
+          socialMedia == _sentinel ? this.socialMedia : socialMedia as String?,
       hobbies: hobbies == _sentinel ? this.hobbies : hobbies as String?,
       documents: documents == _sentinel ? this.documents : documents as String?,
       documentsList: documentsList == _sentinel
@@ -124,6 +124,10 @@ class FamilyMember {
       messengers: messengers == _sentinel
           ? this.messengers
           : messengers as List<Map<String, String>>?,
+      createdAt:
+          createdAt == _sentinel ? this.createdAt : createdAt as DateTime?,
+      updatedAt:
+          updatedAt == _sentinel ? this.updatedAt : updatedAt as DateTime?,
     );
   }
 }

--- a/FamilyAppFlutter/lib/models/friend.dart
+++ b/FamilyAppFlutter/lib/models/friend.dart
@@ -1,28 +1,61 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import '../utils/parsing.dart';
 
+/// Represents a friendly family that the user has connected with.
 class Friend {
-  /// Unique identifier for the friend.
-  final String? id;
+  static const Object _sentinel = Object();
 
-  /// Display name of the friend.
-  final String? name;
+  const Friend({
+    required this.id,
+    required this.name,
+    this.phone,
+    this.notes,
+    this.createdAt,
+    this.updatedAt,
+  });
 
-  Friend({this.id, this.name});
+  final String id;
+  final String name;
+  final String? phone;
+  final String? notes;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
 
-  Map<String, dynamic> toMap() => {
-        'id': id,
-        'name': name,
-      };
-
-  static Friend fromDecodableMap(Map<String, dynamic> map) {
+  factory Friend.fromMap(Map<String, dynamic> map) {
     return Friend(
       id: (map['id'] ?? '').toString(),
-      name: map['name'] as String?,
+      name: (map['name'] ?? '').toString(),
       phone: map['phone'] as String?,
       notes: map['notes'] as String?,
       createdAt: parseNullableDateTime(map['createdAt']),
       updatedAt: parseNullableDateTime(map['updatedAt']),
     );
   }
-}
 
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
+        'name': name,
+        'phone': phone,
+        'notes': notes,
+        'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
+      };
+
+  Friend copyWith({
+    Object? name = _sentinel,
+    Object? phone = _sentinel,
+    Object? notes = _sentinel,
+    Object? createdAt = _sentinel,
+    Object? updatedAt = _sentinel,
+  }) {
+    return Friend(
+      id: id,
+      name: name == _sentinel ? this.name : name as String,
+      phone: phone == _sentinel ? this.phone : phone as String?,
+      notes: notes == _sentinel ? this.notes : notes as String?,
+      createdAt:
+          createdAt == _sentinel ? this.createdAt : createdAt as DateTime?,
+      updatedAt:
+          updatedAt == _sentinel ? this.updatedAt : updatedAt as DateTime?,
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/models/gallery_item.dart
+++ b/FamilyAppFlutter/lib/models/gallery_item.dart
@@ -1,20 +1,26 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import '../utils/parsing.dart';
 
+/// Photo or video stored in the shared family gallery.
 class GalleryItem {
-  final String? id;
+  static const Object _sentinel = Object();
+
+  const GalleryItem({
+    required this.id,
+    this.url,
+    this.storagePath,
+    this.caption,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  final String id;
   final String? url;
   final String? storagePath;
+  final String? caption;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
 
-  GalleryItem({this.id, this.url, this.storagePath});
-
-  Map<String, dynamic> toMap() => {
-        'id': id,
-        'url': url,
-        'storagePath': storagePath,
-      };
-
-
-  static GalleryItem fromDecodableMap(Map<String, dynamic> map) {
+  factory GalleryItem.fromMap(Map<String, dynamic> map) {
     return GalleryItem(
       id: (map['id'] ?? '').toString(),
       url: map['url'] as String?,
@@ -24,5 +30,34 @@ class GalleryItem {
       updatedAt: parseNullableDateTime(map['updatedAt']),
     );
   }
-}
 
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
+        'url': url,
+        'storagePath': storagePath,
+        'caption': caption,
+        'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
+      };
+
+  GalleryItem copyWith({
+    Object? url = _sentinel,
+    Object? storagePath = _sentinel,
+    Object? caption = _sentinel,
+    Object? createdAt = _sentinel,
+    Object? updatedAt = _sentinel,
+  }) {
+    return GalleryItem(
+      id: id,
+      url: url == _sentinel ? this.url : url as String?,
+      storagePath: storagePath == _sentinel
+          ? this.storagePath
+          : storagePath as String?,
+      caption: caption == _sentinel ? this.caption : caption as String?,
+      createdAt:
+          createdAt == _sentinel ? this.createdAt : createdAt as DateTime?,
+      updatedAt:
+          updatedAt == _sentinel ? this.updatedAt : updatedAt as DateTime?,
+    );
+  }
+}

--- a/FamilyAppFlutter/lib/models/message.dart
+++ b/FamilyAppFlutter/lib/models/message.dart
@@ -1,143 +1,108 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import 'message_type.dart';
+import '../utils/parsing.dart';
 
-enum MessageType { text, image, file }
-
+/// Delivery status of a message stored in Firestore.
 enum MessageStatus { sending, sent, delivered, read }
 
+/// Generic message model used by encrypted call conversations.
 class Message {
-  final String id;
-  final String conversationId;
-  final String senderId;
-  final String content;
-  final DateTime timestamp;
+  static const Object _sentinel = Object();
 
-  Message({
+  const Message({
     required this.id,
     required this.conversationId,
     required this.senderId,
+    required this.type,
     required this.content,
-    required this.timestamp,
+    required this.createdAt,
+    this.editedAt,
+    this.status = MessageStatus.sent,
   });
 
-  Map<String, dynamic> toMap() => {
+  final String id;
+  final String conversationId;
+  final String senderId;
+  final MessageType type;
+  final String content;
+  final DateTime createdAt;
+  final DateTime? editedAt;
+  final MessageStatus status;
+
+  factory Message.fromMap(Map<String, dynamic> map) {
+    return Message(
+      id: (map['id'] ?? '').toString(),
+      conversationId: (map['conversationId'] ?? '').toString(),
+      senderId: (map['senderId'] ?? '').toString(),
+      type: _parseType(map['type']) ?? MessageType.text,
+      content: (map['content'] ?? '').toString(),
+      createdAt: parseDateTimeOrNow(map['createdAt']),
+      editedAt: parseNullableDateTime(map['editedAt']),
+      status: _parseStatus(map['status']) ?? MessageStatus.sent,
+    );
+  }
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
         'id': id,
         'conversationId': conversationId,
         'senderId': senderId,
+        'type': type.name,
         'content': content,
-        'timestamp': timestamp.toIso8601String(),
+        'createdAt': createdAt.toIso8601String(),
+        'editedAt': editedAt?.toIso8601String(),
+        'status': status.name,
       };
 
-  static Message fromDecodableMap(
-    Map<String, dynamic> openData, {
-    required Map<String, dynamic> metadata,
-    required String id,
-    required String conversationId,
-    required String ciphertext,
-    required String iv,
-    required int encVersion,
-  }) {
-
-    DateTime createdAt = parseDateTimeOrNow(metadata['createdAt']);
-    final DateTime? legacyCreated =
-        parseNullableDateTime(openData['createdAtLocal']);
-    if (legacyCreated != null) {
-      createdAt = legacyCreated;
-    }
-    return Message(
-      id: id,
-      conversationId: conversationId,
-      senderId: metadata['senderId']?.toString() ?? '',
-      type: _parseType(metadata['type']),
-      ciphertext: ciphertext,
-      iv: iv,
-      encVersion: encVersion,
-      createdAt: createdAt,
-      editedAt: parseNullableDateTime(metadata['editedAt']),
-      status: _parseStatus(metadata['status']),
-      openData: openData,
-    );
-  }
-
-  static Message fromCache(Map<String, dynamic> map) {
-    return Message.fromDecodableMap(
-      Map<String, dynamic>.from(map['openData'] as Map? ?? <String, dynamic>{}),
-      metadata: <String, dynamic>{
-        'senderId': map['senderId'],
-        'type': map['type'],
-        'status': map['status'],
-        'createdAt': map['createdAt'],
-        'editedAt': map['editedAt'],
-      },
-      id: (map['id'] ?? '').toString(),
-      conversationId: (map['conversationId'] ?? '').toString(),
-      ciphertext: (map['ciphertext'] ?? '').toString(),
-      iv: (map['iv'] ?? '').toString(),
-      encVersion: map['encVersion'] is int
-          ? map['encVersion'] as int
-          : int.tryParse('${map['encVersion']}') ?? 0,
-    );
-  }
-
-  static MessageType _parseType(dynamic value) {
-    if (value is MessageType) {
-      return value;
-    }
-    final String? rawName = value?.toString();
-    if (rawName != null && rawName.isNotEmpty) {
-      final String normalized = rawName.contains('.')
-          ? rawName.substring(rawName.lastIndexOf('.') + 1)
-          : rawName;
-      final String lowerNormalized = normalized.toLowerCase();
-      for (final MessageType type in MessageType.values) {
-        if (type.name.toLowerCase() == lowerNormalized) {
-          return type;
-        }
-      }
-    }
-    return MessageType.text;
-  }
-
-  static MessageStatus _parseStatus(dynamic value) {
-    if (value is MessageStatus) {
-      return value;
-    }
-    final String? rawName = value?.toString();
-    if (rawName != null && rawName.isNotEmpty) {
-      final String normalized = rawName.contains('.')
-          ? rawName.substring(rawName.lastIndexOf('.') + 1)
-          : rawName;
-      final String lowerNormalized = normalized.toLowerCase();
-      for (final MessageStatus status in MessageStatus.values) {
-        if (status.name.toLowerCase() == lowerNormalized) {
-          return status;
-        }
-      }
-    }
-    return MessageStatus.sent;
-  }
-
   Message copyWith({
-    MessageType? type,
-    String? ciphertext,
-    String? iv,
-    int? encVersion,
-    DateTime? createdAt,
-    DateTime? editedAt,
-    MessageStatus? status,
-    Map<String, dynamic>? openData,
+    Object? type = _sentinel,
+    Object? content = _sentinel,
+    Object? createdAt = _sentinel,
+    Object? editedAt = _sentinel,
+    Object? status = _sentinel,
   }) {
     return Message(
       id: id,
       conversationId: conversationId,
       senderId: senderId,
-      type: type ?? this.type,
-      ciphertext: ciphertext ?? this.ciphertext,
-      iv: iv ?? this.iv,
-      encVersion: encVersion ?? this.encVersion,
-      createdAt: createdAt ?? this.createdAt,
-      editedAt: editedAt ?? this.editedAt,
-      status: status ?? this.status,
-      openData: openData ?? this.openData,
+      type: type == _sentinel ? this.type : type as MessageType,
+      content: content == _sentinel ? this.content : content as String,
+      createdAt: createdAt == _sentinel
+          ? this.createdAt
+          : createdAt as DateTime,
+      editedAt:
+          editedAt == _sentinel ? this.editedAt : editedAt as DateTime?,
+      status: status == _sentinel ? this.status : status as MessageStatus,
     );
+  }
+
+  static MessageType? _parseType(dynamic value) {
+    if (value is MessageType) {
+      return value;
+    }
+    final String? name = value?.toString();
+    if (name == null || name.isEmpty) {
+      return null;
+    }
+    for (final MessageType type in MessageType.values) {
+      if (type.name.toLowerCase() == name.toLowerCase()) {
+        return type;
+      }
+    }
+    return null;
+  }
+
+  static MessageStatus? _parseStatus(dynamic value) {
+    if (value is MessageStatus) {
+      return value;
+    }
+    final String? name = value?.toString();
+    if (name == null || name.isEmpty) {
+      return null;
+    }
+    for (final MessageStatus status in MessageStatus.values) {
+      if (status.name.toLowerCase() == name.toLowerCase()) {
+        return status;
+      }
+    }
+    return null;
   }
 }

--- a/FamilyAppFlutter/lib/models/message_type.dart
+++ b/FamilyAppFlutter/lib/models/message_type.dart
@@ -1,0 +1,2 @@
+/// Types of messages supported in chats and conversations.
+enum MessageType { text, image, file }

--- a/FamilyAppFlutter/lib/models/schedule_item.dart
+++ b/FamilyAppFlutter/lib/models/schedule_item.dart
@@ -1,15 +1,10 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import '../utils/parsing.dart';
 
+/// Item in the weekly schedule such as school or extracurricular activity.
 class ScheduleItem {
-  final String id;
-  final String title;
-  final DateTime dateTime;
-  final Duration? duration;
-  final String? location;
-  final String? notes;
-  final String? memberId;
+  static const Object _sentinel = Object();
 
-  ScheduleItem({
+  const ScheduleItem({
     required this.id,
     required this.title,
     required this.dateTime,
@@ -17,28 +12,24 @@ class ScheduleItem {
     this.location,
     this.notes,
     this.memberId,
+    this.createdAt,
+    this.updatedAt,
   });
+
+  final String id;
+  final String title;
+  final DateTime dateTime;
+  final Duration? duration;
+  final String? location;
+  final String? notes;
+  final String? memberId;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
 
   DateTime get endDateTime =>
       duration == null ? dateTime : dateTime.add(duration!);
 
-  Map<String, dynamic> toEncodableMap() => <String, dynamic>{
-        'title': title,
-        'dateTime': dateTime.toIso8601String(),
-        'duration': duration?.inMinutes,
-        'location': location,
-        'notes': notes,
-        'memberId': memberId,
-      };
-
-  Map<String, dynamic> toLocalMap() => <String, dynamic>{
-        'id': id,
-        ...toEncodableMap(),
-        'createdAt': createdAt?.toIso8601String(),
-        'updatedAt': updatedAt?.toIso8601String(),
-      };
-
-  static ScheduleItem fromDecodableMap(Map<String, dynamic> map) {
+  factory ScheduleItem.fromMap(Map<String, dynamic> map) {
     return ScheduleItem(
       id: (map['id'] ?? '').toString(),
       title: (map['title'] ?? '').toString(),
@@ -52,15 +43,41 @@ class ScheduleItem {
     );
   }
 
-  Map<String, dynamic> toMap() {
-    return {
-      'id': id,
-      'title': title,
-      'dateTime': dateTime.toIso8601String(),
-      'duration': duration?.inMinutes,
-      'location': location,
-      'notes': notes,
-      'memberId': memberId,
-    };
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
+        'title': title,
+        'dateTime': dateTime.toIso8601String(),
+        'duration': duration?.inMinutes,
+        'location': location,
+        'notes': notes,
+        'memberId': memberId,
+        'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
+      };
+
+  ScheduleItem copyWith({
+    Object? title = _sentinel,
+    Object? dateTime = _sentinel,
+    Object? duration = _sentinel,
+    Object? location = _sentinel,
+    Object? notes = _sentinel,
+    Object? memberId = _sentinel,
+    Object? createdAt = _sentinel,
+    Object? updatedAt = _sentinel,
+  }) {
+    return ScheduleItem(
+      id: id,
+      title: title == _sentinel ? this.title : title as String,
+      dateTime: dateTime == _sentinel ? this.dateTime : dateTime as DateTime,
+      duration:
+          duration == _sentinel ? this.duration : duration as Duration?,
+      location: location == _sentinel ? this.location : location as String?,
+      notes: notes == _sentinel ? this.notes : notes as String?,
+      memberId: memberId == _sentinel ? this.memberId : memberId as String?,
+      createdAt:
+          createdAt == _sentinel ? this.createdAt : createdAt as DateTime?,
+      updatedAt:
+          updatedAt == _sentinel ? this.updatedAt : updatedAt as DateTime?,
+    );
   }
 }

--- a/FamilyAppFlutter/lib/models/task.dart
+++ b/FamilyAppFlutter/lib/models/task.dart
@@ -1,17 +1,13 @@
-import 'package:family_app_flutter/utils/parsing.dart';
+import '../utils/parsing.dart';
 
+/// Possible states of a task.
 enum TaskStatus { todo, inProgress, done }
 
+/// Model describing a family task with optional assignee and due date.
 class Task {
-  final String id;
-  String title;
-  String? description;
-  DateTime? dueDate;
-  TaskStatus status;
-  String? assigneeId; // id участника семьи
-  int? points; // баллы для поощрений/штрафов
+  static const Object _sentinel = Object();
 
-  Task({
+  const Task({
     required this.id,
     required this.title,
     this.description,
@@ -19,6 +15,8 @@ class Task {
     this.status = TaskStatus.todo,
     this.assigneeId,
     this.points,
+    this.createdAt,
+    this.updatedAt,
   });
 
   final String id;
@@ -31,62 +29,83 @@ class Task {
   final DateTime? createdAt;
   final DateTime? updatedAt;
 
-  Map<String, dynamic> toEncodableMap() => <String, dynamic>{
+  factory Task.fromMap(Map<String, dynamic> map) {
+    return Task(
+      id: (map['id'] ?? '').toString(),
+      title: (map['title'] ?? '').toString(),
+      description: map['description'] as String?,
+      dueDate: parseNullableDateTime(map['dueDate']),
+      status: _statusFromString(map['status']) ?? TaskStatus.todo,
+      assigneeId: map['assigneeId'] as String?,
+      points: _parsePoints(map['points']),
+      createdAt: parseNullableDateTime(map['createdAt']),
+      updatedAt: parseNullableDateTime(map['updatedAt']),
+    );
+  }
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        'id': id,
         'title': title,
         'description': description,
         'dueDate': dueDate?.toIso8601String(),
         'status': status.name,
         'assigneeId': assigneeId,
         'points': points,
-      };
-
-  Map<String, dynamic> toLocalMap() => <String, dynamic>{
-        'id': id,
-        ...toEncodableMap(),
         'createdAt': createdAt?.toIso8601String(),
         'updatedAt': updatedAt?.toIso8601String(),
       };
 
-  static Task fromDecodableMap(Map<String, dynamic> map) {
+  Task copyWith({
+    Object? title = _sentinel,
+    Object? description = _sentinel,
+    Object? dueDate = _sentinel,
+    Object? status = _sentinel,
+    Object? assigneeId = _sentinel,
+    Object? points = _sentinel,
+    Object? createdAt = _sentinel,
+    Object? updatedAt = _sentinel,
+  }) {
     return Task(
-      id: map['id'] as String,
-      title: map['title'] as String,
-      description: map['description'] as String?,
-      dueDate: parseNullableDateTime(map['dueDate']),
-      status: TaskStatus.values.firstWhere(
-        (TaskStatus status) => status.name == map['status'],
-        orElse: () => TaskStatus.todo,
-      ),
-      assigneeId: map['assigneeId'] as String?,
-      points: map['points'] is int
-          ? map['points'] as int
-          : int.tryParse('${map['points']}'),
-      createdAt: parseNullableDateTime(map['createdAt']),
-      updatedAt: parseNullableDateTime(map['updatedAt']),
+      id: id,
+      title: title == _sentinel ? this.title : title as String,
+      description:
+          description == _sentinel ? this.description : description as String?,
+      dueDate: dueDate == _sentinel ? this.dueDate : dueDate as DateTime?,
+      status:
+          status == _sentinel ? this.status : status as TaskStatus,
+      assigneeId:
+          assigneeId == _sentinel ? this.assigneeId : assigneeId as String?,
+      points: points == _sentinel ? this.points : points as int?,
+      createdAt:
+          createdAt == _sentinel ? this.createdAt : createdAt as DateTime?,
+      updatedAt:
+          updatedAt == _sentinel ? this.updatedAt : updatedAt as DateTime?,
     );
   }
 
-  Map<String, dynamic> toMap() {
-    return {
-      'id': id,
-      'title': title,
-      'description': description,
-      'dueDate': dueDate?.toIso8601String(),
-      'status': status.name,
-      'assigneeId': assigneeId,
-      'points': points,
-    };
+  static TaskStatus? _statusFromString(dynamic value) {
+    if (value is TaskStatus) {
+      return value;
+    }
+    final String? raw = value?.toString();
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    for (final TaskStatus status in TaskStatus.values) {
+      if (status.name.toLowerCase() == raw.toLowerCase()) {
+        return status;
+      }
+    }
+    return null;
   }
 
-  static TaskStatus _statusFromString(String? s) {
-    switch (s) {
-      case 'inProgress':
-        return TaskStatus.inProgress;
-      case 'done':
-        return TaskStatus.done;
-      case 'todo':
-      default:
-        return TaskStatus.todo;
+  static int? _parsePoints(dynamic value) {
+    if (value is int) {
+      return value;
     }
+    if (value is String && value.isNotEmpty) {
+      return int.tryParse(value);
+    }
+    return null;
   }
 }

--- a/FamilyAppFlutter/lib/providers/family_data.dart
+++ b/FamilyAppFlutter/lib/providers/family_data.dart
@@ -5,9 +5,9 @@ import '../models/family_member.dart';
 import '../models/task.dart';
 import '../services/firestore_service.dart';
 
-/// Holds shared state for family members, tasks and events.  This
-/// provider exposes methods to add and modify items and notifies
-/// listeners when changes occur.
+/// Holds shared state for family members, tasks and events. This provider
+/// orchestrates persistence through [FirestoreService] and keeps local lists
+/// updated for the UI.
 class FamilyData extends ChangeNotifier {
   FamilyData({required FirestoreService firestore, required this.familyId})
       : _firestore = firestore;
@@ -15,48 +15,33 @@ class FamilyData extends ChangeNotifier {
   final FirestoreService _firestore;
   final String familyId;
 
-  /// All members in the family.
-  final List<FamilyMember> members = [];
+  final List<FamilyMember> members = <FamilyMember>[];
+  final List<Task> tasks = <Task>[];
+  final List<Event> events = <Event>[];
 
-  /// All tasks tracked in the app.
-  final List<Task> tasks = [];
-
-  FamilyMember? memberById(String? memberId) {
-    if (memberId == null) {
-      return null;
-    }
-    for (final FamilyMember member in members) {
-      if (member.id == memberId) {
-        return member;
-      }
-    }
-    return null;
-  }
-
-  FamilyMember? findMemberById(String? memberId) => memberById(memberId);
-  StreamSubscription<List<FamilyMember>>? _membersSub;
-  StreamSubscription<List<Task>>? _tasksSub;
-  StreamSubscription<List<Event>>? _eventsSub;
-
-  bool _isLoading = false;
   bool _loaded = false;
+  bool _isLoading = false;
 
   bool get isLoading => _isLoading;
 
   Future<void> load() async {
-    if (_loaded || _isLoading) return;
+    if (_loaded || _isLoading) {
+      return;
+    }
     _isLoading = true;
     notifyListeners();
     try {
-      final fetchedMembers = await _firestore.fetchFamilyMembers(familyId);
-      final fetchedTasks = await _firestore.fetchTasks(familyId);
-      final fetchedEvents = await _firestore.fetchEvents(familyId);
+      final List<FamilyMember> fetchedMembers =
+          await _firestore.fetchFamilyMembers(familyId);
+      final List<Task> fetchedTasks = await _firestore.fetchTasks(familyId);
+      final List<Event> fetchedEvents = await _firestore.fetchEvents(familyId);
       members
         ..clear()
         ..addAll(fetchedMembers);
       tasks
         ..clear()
         ..addAll(fetchedTasks);
+      _sortTasks();
       events
         ..clear()
         ..addAll(fetchedEvents);
@@ -67,16 +52,12 @@ class FamilyData extends ChangeNotifier {
     }
   }
 
-  /// Forces a reload of the data from Firestore.
-  Future<void> refresh() async {
-    _loaded = false;
-    await load();
-  }
-
-  /// Returns the member with [id] or null if not found.
-  FamilyMember? memberById(String id) {
+  FamilyMember? memberById(String? memberId) {
+    if (memberId == null) {
+      return null;
+    }
     try {
-      return members.firstWhere((member) => member.id == id);
+      return members.firstWhere((FamilyMember member) => member.id == memberId);
     } catch (_) {
       return null;
     }
@@ -90,7 +71,7 @@ class FamilyData extends ChangeNotifier {
 
   Future<void> updateMember(FamilyMember member) async {
     await _firestore.upsertFamilyMember(familyId, member);
-    final index = members.indexWhere((m) => m.id == member.id);
+    final int index = members.indexWhere((FamilyMember m) => m.id == member.id);
     if (index != -1) {
       members[index] = member;
       notifyListeners();
@@ -115,6 +96,26 @@ class FamilyData extends ChangeNotifier {
     await _firestore.updateFamilyMember(familyId, updated);
   }
 
+  Future<void> updateMemberNetworks({
+    required String memberId,
+    List<Map<String, String>>? socialNetworks,
+    List<Map<String, String>>? messengers,
+    String? socialSummary,
+  }) async {
+    final int index = members.indexWhere((FamilyMember m) => m.id == memberId);
+    if (index == -1) {
+      return;
+    }
+    final FamilyMember updated = members[index].copyWith(
+      socialNetworks: socialNetworks,
+      messengers: messengers,
+      socialMedia: socialSummary,
+    );
+    members[index] = updated;
+    notifyListeners();
+    await _firestore.updateFamilyMember(familyId, updated);
+  }
+
   Future<void> updateMemberHobbies(String memberId, String? hobbies) async {
     final int index = members.indexWhere((FamilyMember m) => m.id == memberId);
     if (index == -1) {
@@ -128,57 +129,19 @@ class FamilyData extends ChangeNotifier {
 
   Future<void> removeMember(FamilyMember member) async {
     await _firestore.deleteFamilyMember(familyId, member.id);
-    members.removeWhere((m) => m.id == member.id);
+    members.removeWhere((FamilyMember m) => m.id == member.id);
     notifyListeners();
   }
 
   Future<void> removeMemberById(String id) async {
     await _firestore.deleteFamilyMember(familyId, id);
-    members.removeWhere((member) => member.id == id);
+    members.removeWhere((FamilyMember member) => member.id == id);
     notifyListeners();
-  }
-
-  Future<void> updateMemberDocuments(
-    String memberId, {
-    String? summary,
-    List<Map<String, String>>? documentsList,
-  }) async {
-    final member = memberById(memberId);
-    if (member == null) return;
-    await updateMember(
-      member.copyWith(
-        documents: summary,
-        documentsList: documentsList,
-      ),
-    );
-  }
-
-  Future<void> updateMemberNetworks({
-    required String memberId,
-    List<Map<String, String>>? socialNetworks,
-    List<Map<String, String>>? messengers,
-    String? socialSummary,
-  }) async {
-    final member = memberById(memberId);
-    if (member == null) return;
-    await updateMember(
-      member.copyWith(
-        socialNetworks: socialNetworks,
-        messengers: messengers,
-        socialMedia: socialSummary,
-      ),
-    );
-  }
-
-  Future<void> updateMemberHobbies(String memberId, String? hobbies) async {
-    final member = memberById(memberId);
-    if (member == null) return;
-    await updateMember(member.copyWith(hobbies: hobbies));
   }
 
   Task? taskById(String id) {
     try {
-      return tasks.firstWhere((task) => task.id == id);
+      return tasks.firstWhere((Task task) => task.id == id);
     } catch (_) {
       return null;
     }
@@ -187,14 +150,16 @@ class FamilyData extends ChangeNotifier {
   Future<void> addTask(Task task) async {
     await _firestore.upsertTask(familyId, task);
     tasks.add(task);
+    _sortTasks();
     notifyListeners();
   }
 
   Future<void> updateTask(Task task) async {
     await _firestore.upsertTask(familyId, task);
-    final index = tasks.indexWhere((t) => t.id == task.id);
+    final int index = tasks.indexWhere((Task t) => t.id == task.id);
     if (index != -1) {
       tasks[index] = task;
+      _sortTasks();
       notifyListeners();
     }
   }
@@ -204,40 +169,36 @@ class FamilyData extends ChangeNotifier {
     if (index == -1) {
       return;
     }
-    final Task updated = tasks[index].copyWith(status: status);
+    final Task updated = tasks[index].copyWith(
+      status: status,
+      updatedAt: DateTime.now(),
+    );
     tasks[index] = updated;
-    tasks.sort((Task a, Task b) =>
-        (a.dueDate ?? DateTime.fromMillisecondsSinceEpoch(0))
-            .compareTo(b.dueDate ?? DateTime.fromMillisecondsSinceEpoch(0)));
+    _sortTasks();
+    notifyListeners();
+    await _firestore.updateTask(familyId, updated);
+  }
+
+  Future<void> assignTask(String id, String? assigneeId) async {
+    final int index = tasks.indexWhere((Task task) => task.id == id);
+    if (index == -1) {
+      return;
+    }
+    final Task updated = tasks[index].copyWith(assigneeId: assigneeId);
+    tasks[index] = updated;
     notifyListeners();
     await _firestore.updateTask(familyId, updated);
   }
 
   Future<void> removeTask(String id) async {
     await _firestore.deleteTask(familyId, id);
-    tasks.removeWhere((task) => task.id == id);
-    notifyListeners();
-  }
-
-  Future<void> updateTaskStatus(String id, TaskStatus status) async {
-    final task = taskById(id);
-    if (task == null) return;
-    task.status = status;
-    await _firestore.upsertTask(familyId, task);
-    notifyListeners();
-  }
-
-  Future<void> assignTask(String id, String? assigneeId) async {
-    final task = taskById(id);
-    if (task == null) return;
-    task.assigneeId = assigneeId;
-    await _firestore.upsertTask(familyId, task);
+    tasks.removeWhere((Task task) => task.id == id);
     notifyListeners();
   }
 
   Event? eventById(String id) {
     try {
-      return events.firstWhere((event) => event.id == id);
+      return events.firstWhere((Event event) => event.id == id);
     } catch (_) {
       return null;
     }
@@ -251,7 +212,7 @@ class FamilyData extends ChangeNotifier {
 
   Future<void> updateEvent(Event event) async {
     await _firestore.upsertEvent(familyId, event);
-    final index = events.indexWhere((e) => e.id == event.id);
+    final int index = events.indexWhere((Event e) => e.id == event.id);
     if (index != -1) {
       events[index] = event;
       notifyListeners();
@@ -260,7 +221,15 @@ class FamilyData extends ChangeNotifier {
 
   Future<void> removeEvent(String id) async {
     await _firestore.deleteEvent(familyId, id);
-    events.removeWhere((event) => event.id == id);
+    events.removeWhere((Event event) => event.id == id);
     notifyListeners();
+  }
+
+  void _sortTasks() {
+    tasks.sort((Task a, Task b) {
+      final DateTime aDue = a.dueDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final DateTime bDue = b.dueDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return aDue.compareTo(bDue);
+    });
   }
 }

--- a/FamilyAppFlutter/lib/providers/gallery_data.dart
+++ b/FamilyAppFlutter/lib/providers/gallery_data.dart
@@ -52,7 +52,7 @@ class GalleryData extends ChangeNotifier {
     );
     if (index == -1) return;
     final item = items[index];
-    await _firestore.deleteGalleryItem(familyId, item.id ?? idOrUrl);
+    await _firestore.deleteGalleryItem(familyId, item.id);
     if (item.storagePath != null) {
       await _storage.deleteByPath(item.storagePath!);
     } else if (item.url != null) {


### PR DESCRIPTION
## Summary
- rewrite the app entry point to initialise Firebase/Hive once and register shared providers for every feature module
- add a shared `MessageType` definition and rebuild every domain model with consistent constructors, `fromMap`, `toMap` and `copyWith` helpers
- update chat/family/gallery providers to use immutable models and delegate persistence to a fully implemented Firestore service that handles encryption-aware CRUD for all collections

## Testing
- ⚠️ `dart format ..` *(missing `dart` SDK in the execution environment)*
- ⚠️ `flutter analyze` *(missing Flutter SDK in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a790ef90832baccfbc0545fe99a0