### PR TITLE
Fix Firebase initialization and update Android toolchain

### DIFF
--- a/FamilyAppFlutter/android/app/build.gradle.kts
+++ b/FamilyAppFlutter/android/app/build.gradle.kts
@@ -17,14 +17,14 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        // ANDROID-ONLY FIX: Use Java 8 compatibility for Android builds.
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        // ANDROID-ONLY FIX: Use Java 17 compatibility for Android builds.
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        // ANDROID-ONLY FIX: Ensure Kotlin bytecode targets JVM 1.8 for Android.
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        // ANDROID-ONLY FIX: Ensure Kotlin bytecode targets JVM 17 for Android.
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {

--- a/FamilyAppFlutter/lib/bootstrap.dart
+++ b/FamilyAppFlutter/lib/bootstrap.dart
@@ -1,7 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_core/firebase_core.dart';
-
-import 'firebase_options.dart';
 import 'security/secure_key_service.dart';
 import 'services/analytics_service.dart';
 import 'services/crashlytics_service.dart';
@@ -11,7 +8,6 @@ import 'services/geo_reminders_service.dart';
 import 'storage/local_store.dart';
 
 Future<void> bootstrap() async {
-  await _ensureFirebaseInitialized();
 
   FirebaseFirestore.instance.settings = const Settings(
     persistenceEnabled: true,
@@ -29,15 +25,4 @@ Future<void> bootstrap() async {
 
   // ANDROID-ONLY FIX: hydrate Remote Config before rendering Android UI gates.
   await RemoteConfigService.instance.init();
-}
-
-Future<void> _ensureFirebaseInitialized() async {
-  if (Firebase.apps.isEmpty) {
-    // ANDROID-ONLY FIX: initialize Firebase for the Android-only target.
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-  } else {
-    Firebase.app();
-  }
 }

--- a/FamilyAppFlutter/lib/core/firebase_boot.dart
+++ b/FamilyAppFlutter/lib/core/firebase_boot.dart
@@ -1,0 +1,16 @@
+import 'package:firebase_core/firebase_core.dart';
+import '../firebase_options.dart';
+
+Future<FirebaseApp> initFirebaseOnce() async {
+  if (Firebase.apps.isNotEmpty) return Firebase.apps.first;
+  try {
+    return await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } on FirebaseException catch (e) {
+    if (e.code == 'duplicate-app') {
+      return Firebase.app();
+    }
+    rethrow;
+  }
+}

--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 // ANDROID-ONLY FIX: centralized bootstrap injects Firebase/config without direct AppConfig wiring.
 import 'bootstrap.dart';
+import 'core/firebase_boot.dart';
 import 'l10n/app_localizations.dart';
 import 'providers/auth_provider.dart';
 import 'providers/chat_provider.dart';
@@ -41,6 +42,7 @@ import 'storage/local_store.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await initFirebaseOnce();
   await bootstrap(); // ANDROID-ONLY FIX: serialized Android bootstrap flow.
   runZonedGuarded(
     () => runApp(const FamilyApp()),

--- a/FamilyAppFlutter/lib/services/notifications_service.dart
+++ b/FamilyAppFlutter/lib/services/notifications_service.dart
@@ -431,7 +431,10 @@ class NotificationsService {
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   if (Firebase.apps.isEmpty) {
     // ANDROID-ONLY FIX: background isolate needs its own Firebase bootstrap.
-    await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+    await Firebase.initializeApp(
+      name: 'background',
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
   }
 
   final FlutterLocalNotificationsPlugin plugin =


### PR DESCRIPTION
## Summary
- add a guarded Firebase initialization helper and call it during app startup
- remove duplicate initializeApp usages and configure the background isolate with a named app
- bump Android Java/Kotlin compatibility settings to version 17

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7638f38c8832bb9495934d57bf771