### PR TITLE
fix: ensure Firebase initializes once and target Java 17

### DIFF
--- a/FamilyAppFlutter/android/app/build.gradle.kts
+++ b/FamilyAppFlutter/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 
     kotlinOptions {
         // ANDROID-ONLY FIX: Ensure Kotlin bytecode targets JVM 17 for Android.
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = "17"
     }
 
     defaultConfig {

--- a/FamilyAppFlutter/lib/core/firebase_boot.dart
+++ b/FamilyAppFlutter/lib/core/firebase_boot.dart
@@ -1,16 +1,24 @@
+// lib/core/firebase_boot.dart
 import 'package:firebase_core/firebase_core.dart';
-import '../firebase_options.dart';
 
-Future<FirebaseApp> initFirebaseOnce() async {
-  if (Firebase.apps.isNotEmpty) return Firebase.apps.first;
-  try {
-    return await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-  } on FirebaseException catch (e) {
-    if (e.code == 'duplicate-app') {
-      return Firebase.app();
+class FirebaseBoot {
+  static FirebaseApp? _cached;
+
+  static Future<FirebaseApp> ensureInitialized() async {
+    if (_cached != null) return _cached!;
+    if (Firebase.apps.isNotEmpty) {
+      _cached = Firebase.apps.first;
+      return _cached!;
     }
-    rethrow;
+    try {
+      _cached = await Firebase.initializeApp(); // Android возьмёт конфиг из google-services.json
+      return _cached!;
+    } on FirebaseException catch (e) {
+      if (e.code == 'duplicate-app') {
+        _cached = Firebase.app();
+        return _cached!;
+      }
+      rethrow;
+    }
   }
 }

--- a/FamilyAppFlutter/lib/main.dart
+++ b/FamilyAppFlutter/lib/main.dart
@@ -42,7 +42,7 @@ import 'storage/local_store.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await initFirebaseOnce();
+  await FirebaseBoot.ensureInitialized(); // единственная инициализация
   await bootstrap(); // ANDROID-ONLY FIX: serialized Android bootstrap flow.
   runZonedGuarded(
     () => runApp(const FamilyApp()),

--- a/FamilyAppFlutter/lib/services/notifications_service.dart
+++ b/FamilyAppFlutter/lib/services/notifications_service.dart
@@ -2,13 +2,12 @@ import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
-import '../firebase_options.dart';
+import '../core/firebase_boot.dart';
 import '../storage/local_store.dart';
 
 class NotificationsService {
@@ -429,13 +428,8 @@ class NotificationsService {
 
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  if (Firebase.apps.isEmpty) {
-    // ANDROID-ONLY FIX: background isolate needs its own Firebase bootstrap.
-    await Firebase.initializeApp(
-      name: 'background',
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-  }
+  // ANDROID-ONLY FIX: background isolate needs its own Firebase bootstrap.
+  await FirebaseBoot.ensureInitialized();
 
   final FlutterLocalNotificationsPlugin plugin =
       FlutterLocalNotificationsPlugin();


### PR DESCRIPTION
## Summary
- add a FirebaseBoot helper that caches the Firebase app and handles duplicate-app errors
- update the app entry point and notification background handler to use the shared initializer
- align the Android module with Java/Kotlin 17 targets to silence obsolete toolchain warnings

## Testing
- flutter clean && flutter pub get && flutter analyze *(fails: Flutter SDK unavailable in container)*
- flutter run -d emulator-5554 *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d779f0273c832b81deaca24e4323bb