### PR TITLE
Fix Android Gradle plugin classpath conflict

### DIFF
--- a/FamilyAppFlutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/FamilyAppFlutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip

--- a/FamilyAppFlutter/android/settings.gradle.kts
+++ b/FamilyAppFlutter/android/settings.gradle.kts
@@ -1,41 +1,24 @@
-// FamilyAppFlutter/android/settings.gradle.kts
-
 pluginManagement {
     repositories {
-        // Local plugin shelf: allows offline Gradle builds when jars are present in android/gradle/plugins.
-        flatDir {
-            dirs = setOf(file("gradle/plugins"))
-        }
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven { url = uri("https://storage.googleapis.com/download.flutter.io") }
     }
     plugins {
         id("com.android.application") version "8.9.1"
         id("org.jetbrains.kotlin.android") version "1.9.24"
-        // The Flutter Gradle plugin version is provided by the Flutter SDK.
-    }
-    resolutionStrategy {
-        eachPlugin {
-            when (requested.id.id) {
-                "org.jetbrains.kotlin.android" ->
-                    useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
-                "com.android.application" ->
-                    useModule("com.android.tools.build:gradle:8.9.1")
-                "com.google.gms.google-services" ->
-                    useModule("com.google.gms:google-services:4.4.2")
-            }
-        }
+        id("com.google.gms.google-services") version "4.4.2"
+        id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     }
 }
 
+plugins {
+    id("dev.flutter.flutter-plugin-loader")
+}
+
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        flatDir {
-            dirs = setOf(file("gradle/plugins"))
-        }
         google()
         mavenCentral()
         maven { url = uri("https://storage.googleapis.com/download.flutter.io") }


### PR DESCRIPTION
## Summary
- centralize Android plugin versions in `settings.gradle.kts` via `pluginManagement` and apply Flutter's plugin loader without duplicate classpath entries
- enforce repository resolution from settings with `FAIL_ON_PROJECT_REPOS` while keeping the Flutter Maven repository available
- align the Gradle wrapper with AGP 8.9.1 by switching to Gradle 8.10.2 bin distribution

## Testing
- `./gradlew tasks` *(fails: Gradle wrapper cannot download distribution because the sandbox has no external network access)*
- `flutter build apk --debug` *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f12b7883c4832baa6e380c6ed25841